### PR TITLE
Output for storing image build information in a single place (DRY)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,12 +9,6 @@ on:
   # Allow to run this workflow manually
   workflow_dispatch:
 
-env:
-  GITHUB_RUN_ID: ${{ github.run_id }}
-  CONTAINER_REGISTRY: "ghr.io"
-  CONTAINER_IMAGE_NAME: ${{ github.repository }}
-  CONTAINER_IMAGE_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
-
 jobs:
   ########################################
   # Jobs operating on the whole repository
@@ -27,14 +21,19 @@ jobs:
       contents: read
       security-events: write # trivy scan needs this
 
-  # Due to a GitHub bug (https://github.com/actions/runner/issues/480), 
+  # Due to a GitHub bug (https://github.com/actions/runner/issues/480),
   # we need to set the env vars manually for our use case
   setup-env-vars:
     runs-on: ubuntu-latest
     steps:
       - name: Set docker image related environment variables
-        run: echo "CONTAINER_REGISTRY=ghr.io" >> $GITHUB_ENV
-    
+        run: |
+          echo "GITHUB_RUN_ID=${{ github.run_id }}" >> $GITHUB_ENV
+          echo "CONTAINER_REGISTRY=ghr.io" >> $GITHUB_ENV
+          echo "CONTAINER_IMAGE_NAME={{ github.repository }}" >> $GITHUB_ENV
+          echo "CONTAINER_IMAGE_VERSION=${{ github.event.pull_request.head.sha || github.sha }} >> $GITHUB_ENV
+      - name: Show env vars
+        run: echo $GITHUB_ENV
 
   ###############
   # Frontend jobs
@@ -47,6 +46,8 @@ jobs:
   frontend-build-image-and-scan:
     uses: ./.github/workflows/frontend-build-image-and-scan.yml
     secrets: inherit
+    needs:
+      - setup-env-vars
     permissions:
       contents: read
       security-events: write
@@ -58,7 +59,7 @@ jobs:
 
   frontend-push-image-to-registry:
     if: ${{ github.ref == 'refs/heads/main' }}
-    # For PR releases, labels could be used like this: 
+    # For PR releases, labels could be used like this:
     # if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'dev-env') || contains(github.event.labeled.labels.*.name, 'dev-env') }}
     uses: ./.github/workflows/frontend-push-image-to-registry.yml
     secrets: inherit
@@ -67,6 +68,7 @@ jobs:
       id-token: write # This is used to complete the identity challenge with sigstore/fulcio..
       packages: write
     needs:
+      - setup-env-vars
       - security-jobs
       - frontend-checks
       - frontend-build-image-and-scan
@@ -80,6 +82,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/frontend-deploy-staging.yml
     needs:
+      - setup-env-vars
       - security-jobs
       - frontend-checks
       - frontend-build-image-and-scan

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,16 +15,9 @@ on:
 
 jobs:
 
-  ########################################
-  # Jobs operating on the whole repository
-  ########################################
-
-  security-jobs:
-    uses: ./.github/workflows/security-jobs.yml
-    secrets: inherit # so the backend workflow can access "secrets.SLACK_WEBHOOK_URL" and others
-    permissions:
-      contents: read
-      security-events: write # trivy scan needs this
+  ###############
+  # Workflow jobs
+  ###############
 
   # Due to a GitHub bug (https://github.com/actions/runner/issues/480),
   # we need to set the env vars manually for our use case
@@ -45,6 +38,18 @@ jobs:
           echo "CONTAINER_IMAGE_VERSION=${{ github.event.pull_request.head.sha || github.sha }}" >> $GITHUB_OUTPUT
       - name: Show env vars
         run: echo $GITHUB_OUTPUT
+
+  #################
+  # Repository jobs
+  #################
+
+  security-jobs:
+    uses: ./.github/workflows/security-jobs.yml
+    secrets: inherit # so the backend workflow can access "secrets.SLACK_WEBHOOK_URL" and others
+    permissions:
+      contents: read
+      security-events: write # trivy scan needs this
+
 
   ###############
   # Frontend jobs

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,7 +30,7 @@ jobs:
       GITHUB_RUN_ID: ${{ steps.set-env-vars.outputs.GITHUB_RUN_ID}}
       CONTAINER_REGISTRY: ${{ steps.set-env-vars.outputs.CONTAINER_REGISTRY}}
       CONTAINER_IMAGE_NAME: ${{ steps.set-env-vars.outputs.CONTAINER_IMAGE_NAME}}
-      GCONTAINER_IMAGE_VERSION: ${{ steps.set-env-vars.outputs.CONTAINER_IMAGE_VERSION}}
+      CONTAINER_IMAGE_VERSION: ${{ steps.set-env-vars.outputs.CONTAINER_IMAGE_VERSION}}
     steps:
       - name: Set docker image related environment variables
         id: set-env-vars

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   GITHUB_RUN_ID: ${{ github.run_id }}
-  CONTAINER_REGISTRY: ghr.io
+  CONTAINER_REGISTRY: "ghr.io"
   CONTAINER_IMAGE_NAME: ${{ github.repository }}
   CONTAINER_IMAGE_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -27,6 +27,15 @@ jobs:
       contents: read
       security-events: write # trivy scan needs this
 
+  # Due to a GitHub bug (https://github.com/actions/runner/issues/480), 
+  # we need to set the env vars manually for our use case
+  setup-env-vars:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set docker image related environment variables
+        run: echo "CONTAINER_REGISTRY=ghr.io" >> $GITHUB_ENV
+    
+
   ###############
   # Frontend jobs
   ###############

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           echo "GITHUB_RUN_ID=${{ github.run_id }}" >> $GITHUB_OUTPUT
           echo "CONTAINER_REGISTRY=ghr.io" >> $GITHUB_OUTPUT
-          echo "CONTAINER_IMAGE_NAME={{ github.repository }}" >> $GITHUB_OUTPUT
+          echo "CONTAINER_IMAGE_NAME=${{ github.repository }}" >> $GITHUB_OUTPUT
           echo "CONTAINER_IMAGE_VERSION=${{ github.event.pull_request.head.sha || github.sha }}" >> $GITHUB_OUTPUT
       - name: Show env vars
         run: echo $GITHUB_OUTPUT

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,7 +38,7 @@ jobs:
           echo "GITHUB_RUN_ID=${{ github.run_id }}" >> $GITHUB_OUTPUT
           echo "CONTAINER_REGISTRY=ghr.io" >> $GITHUB_OUTPUT
           echo "CONTAINER_IMAGE_NAME={{ github.repository }}" >> $GITHUB_OUTPUT
-          echo "CONTAINER_IMAGE_VERSION=${{ github.event.pull_request.head.sha || github.sha }} >> $GITHUB_OUTPUT
+          echo "CONTAINER_IMAGE_VERSION=${{ github.event.pull_request.head.sha || github.sha }}" >> $GITHUB_OUTPUT
       - name: Show env vars
         run: echo $GITHUB_OUTPUT
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -59,10 +59,10 @@ jobs:
       contents: read
       security-events: write
     with:
-      run-id: ${{ steps.set-env-vars.outputs.GITHUB_RUN_ID}}
-      container-registry: ${{ steps.set-env-vars.outputs.CONTAINER_REGISTRY}}
-      container-image-name: ${{ steps.set-env-vars.outputs.CONTAINER_IMAGE_NAME}}
-      container-image-version: ${{ steps.set-env-vars.outputs.CONTAINER_IMAGE_VERSION}}
+      run-id: ${{ needs.setup-env-vars.outputs.GITHUB_RUN_ID}}
+      container-registry: ${{ needs.setup-env-vars.outputs.CONTAINER_REGISTRY}}
+      container-image-name: ${{ needs.setup-env-vars.outputs.CONTAINER_IMAGE_NAME}}
+      container-image-version: ${{ needs.setup-env-vars.outputs.CONTAINER_IMAGE_VERSION}}
 
   frontend-push-image-to-registry:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
   # Allow to run this workflow manually
   workflow_dispatch:
+    
+# env:
+# Setting the container information via the env key does not work we use outputs instead
+# cf. the "setup-env-vars" job below for details
 
 jobs:
 
@@ -80,10 +84,10 @@ jobs:
       - frontend-checks
       - frontend-build-image-and-scan
     with:
-      run-id: ${{ github.run_id }}
-      container-registry: ghcr.io
-      container-image-name: ${{ github.repository }}
-      container-image-version: ${{ github.event.pull_request.head.sha || github.sha }}
+      run-id: ${{ needs.setup-env-vars.outputs.GITHUB_RUN_ID}}
+      container-registry: ${{ needs.setup-env-vars.outputs.CONTAINER_REGISTRY}}
+      container-image-name: ${{ needs.setup-env-vars.outputs.CONTAINER_IMAGE_NAME}}
+      container-image-version: ${{ needs.setup-env-vars.outputs.CONTAINER_IMAGE_VERSION}}
 
   frontend-deploy-staging:
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -98,4 +102,4 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      container-image-version: ${{ github.event.pull_request.head.sha || github.sha }}
+      container-image-version: ${{ needs.setup-env-vars.outputs.CONTAINER_IMAGE_VERSION}}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,6 +9,12 @@ on:
   # Allow to run this workflow manually
   workflow_dispatch:
 
+env:
+  GITHUB_RUN_ID: ${{ github.run_id }}
+  CONTAINER_REGISTRY: ghr.io
+  CONTAINER_IMAGE_NAME: ${{ github.repository }}
+  CONTAINER_IMAGE_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
+
 jobs:
   ########################################
   # Jobs operating on the whole repository
@@ -36,10 +42,10 @@ jobs:
       contents: read
       security-events: write
     with:
-      run-id: ${{ github.run_id }}
-      container-registry: ghcr.io
-      container-image-name: ${{ github.repository }}
-      container-image-version: ${{ github.event.pull_request.head.sha || github.sha }}
+      run-id: ${{ env.GITHUB_RUN_ID }}
+      container-registry: ${{ env.CONTAINER_REGISTRY }}
+      container-image-name: ${{ env.CONTAINER_IMAGE_NAME }}
+      container-image-version: ${{ env.CONTAINER_IMAGE_VERSION }}
 
   frontend-push-image-to-registry:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
+
   ########################################
   # Jobs operating on the whole repository
   ########################################
@@ -25,15 +26,21 @@ jobs:
   # we need to set the env vars manually for our use case
   setup-env-vars:
     runs-on: ubuntu-latest
+    outputs:
+      GITHUB_RUN_ID: ${{ steps.set-env-vars.outputs.GITHUB_RUN_ID}}
+      CONTAINER_REGISTRY: ${{ steps.set-env-vars.outputs.CONTAINER_REGISTRY}}
+      CONTAINER_IMAGE_NAME: ${{ steps.set-env-vars.outputs.CONTAINER_IMAGE_NAME}}
+      GCONTAINER_IMAGE_VERSION: ${{ steps.set-env-vars.outputs.CONTAINER_IMAGE_VERSION}}
     steps:
       - name: Set docker image related environment variables
+        id: set-env-vars
         run: |
-          echo "GITHUB_RUN_ID=${{ github.run_id }}" >> $GITHUB_ENV
-          echo "CONTAINER_REGISTRY=ghr.io" >> $GITHUB_ENV
-          echo "CONTAINER_IMAGE_NAME={{ github.repository }}" >> $GITHUB_ENV
-          echo "CONTAINER_IMAGE_VERSION=${{ github.event.pull_request.head.sha || github.sha }} >> $GITHUB_ENV
+          echo "GITHUB_RUN_ID=${{ github.run_id }}" >> $GITHUB_OUTPUT
+          echo "CONTAINER_REGISTRY=ghr.io" >> $GITHUB_OUTPUT
+          echo "CONTAINER_IMAGE_NAME={{ github.repository }}" >> $GITHUB_OUTPUT
+          echo "CONTAINER_IMAGE_VERSION=${{ github.event.pull_request.head.sha || github.sha }} >> $GITHUB_OUTPUT
       - name: Show env vars
-        run: echo $GITHUB_ENV
+        run: echo $GITHUB_OUTPUT
 
   ###############
   # Frontend jobs
@@ -52,10 +59,10 @@ jobs:
       contents: read
       security-events: write
     with:
-      run-id: ${{ env.GITHUB_RUN_ID }}
-      container-registry: ${{ env.CONTAINER_REGISTRY }}
-      container-image-name: ${{ env.CONTAINER_IMAGE_NAME }}
-      container-image-version: ${{ env.CONTAINER_IMAGE_VERSION }}
+      run-id: ${{ steps.set-env-vars.outputs.GITHUB_RUN_ID}}
+      container-registry: ${{ steps.set-env-vars.outputs.CONTAINER_REGISTRY}}
+      container-image-name: ${{ steps.set-env-vars.outputs.CONTAINER_IMAGE_NAME}}
+      container-image-version: ${{ steps.set-env-vars.outputs.CONTAINER_IMAGE_VERSION}}
 
   frontend-push-image-to-registry:
     if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
PRO:
  * The env vars are defined in a single place (DRY) 
![image](https://github.com/user-attachments/assets/d15d0deb-35f6-4551-b259-39d22be83858)


CON:
 * Accessing the vars requires a long string
![image](https://github.com/user-attachments/assets/f719fd54-3eb3-42bd-a1d8-1b028951f079)
