### PR TITLE
Make headless mode default for local environment

### DIFF
--- a/frontend/DEVELOPING.md
+++ b/frontend/DEVELOPING.md
@@ -65,6 +65,10 @@ npm run test:e2e -- e2e/AbgabePage.spec.ts
 npm run test:e2e -- --debug
 # Runs the tests only on Chromium and for a specific file and in debug mode
 npm run test:e2e -- e2e/AbgabePage.spec.ts --debug --project=chromium
+# Run tests in interactive UI mode.
+npm run test:e2e -- --ui
+# Run tests in headed browsers
+npm run test:e2e -- --headed
 ```
 
 ### Lint with [ESLint](https://eslint.org/)

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -46,9 +46,6 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
 
-    /* Only on CI systems run the tests headless */
-    headless: !!process.env.CI,
-
     screenshot: process.env.CI ? 'off' : 'only-on-failure',
   },
 


### PR DESCRIPTION
- playwright is using headless mode by default
- the settings are that it remains headless in the pipeline but is using headed mode when run locally
- the problem is that there is no headless cli switch and it is therefore not possible to switch to headless if needed
- proposal is to remove the config setting to have headless in every environment
- and adding readme hints how to run headed if needed