### PR TITLE
Review of Trivy fs scan action

### DIFF
--- a/.github/workflows/security-jobs.yml
+++ b/.github/workflows/security-jobs.yml
@@ -70,6 +70,11 @@ jobs:
           name: trivy-fs-results.sarif
           retention-days: 3
           path: trivy-fs-results.sarif
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: ${{ always() && github.ref == 'refs/heads/main' }} # Bypass non-zero exit code..
+        with:
+          sarif_file: "trivy-fs-results.sarif"
       - name: On failure send status to Slack
         # only on failure and if on "main" branch
         if: ${{ failure() && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
I propose three changes:
1. rename action step to "fs" as trivy is not running in repo mode, which also [exists](https://trivy.dev/latest/docs/target/repository/).
2. Upload this scan result to the GH security tab
3. rename the artifact to not mention "frontend" as this covers both