### PR TITLE
Verweise: Hide "Weitere Einzelnorm" and "x" for deletion - if Verwaltungsvorschrift is selected (RISDEV-6618)

### DIFF
--- a/frontend/e2e/RubrikenPage/Verweise.Verwaltungsvorschrift.spec.ts
+++ b/frontend/e2e/RubrikenPage/Verweise.Verwaltungsvorschrift.spec.ts
@@ -31,4 +31,8 @@ test.describe('Verweise: Verwaltungsvorschrift', () => {
     // then
     await expect(page.getByRole('button', { name: "Weitere Einzelnorm"})).toHaveCount(0) 
   })
+
+  // TODO: Show the button when a norm is selected
+
+  // TODO: remove the "x" when a ADM is selected, show the x when a norm is selected
 })

--- a/frontend/e2e/RubrikenPage/Verweise.Verwaltungsvorschrift.spec.ts
+++ b/frontend/e2e/RubrikenPage/Verweise.Verwaltungsvorschrift.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Verweise: Verwaltungsvorschrift', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('/api/documentation-units/KSNR054920707', async (route) => {
+      const json = {
+        documentNumber: 'KSNR054920707',
+        id: '8de5e4a0-6b67-4d65-98db-efe877a260c4',
+        json: null,
+      }
+      await route.fulfill({ json })
+    })
+  })
+
+  test('Do not show the button "Weitere Einzelnorm"', async ({ page }) => {
+    // given
+    await page.goto('/documentUnit/KSNR054920707/rubriken')
+    await page.getByRole('radio', { name: 'Verwaltungsvorschrift auswä' }).click()
+    await page.getByRole('textbox', { name: 'Art der Verweisung' }).click()
+    await page
+      .getByRole('button', { name: 'dropdown-option' })
+      .filter({ hasText: 'Anwendung' })
+      .click()
+    await page.getByRole('textbox', { name: 'Suche nach Verwaltungsvorschrift' }).click()
+    await page
+      .getByRole('button', { name: 'dropdown-option' })
+      .filter({ hasText: 'SGB 5Sozialgesetzbuch (SGB) F' })
+      .click()
+    await page.getByRole('textbox', { name: 'Fassungsdatum der Norm' }).click()
+    await page.getByRole('textbox', { name: 'Fassungsdatum der Norm' }).fill('12.12.2024')
+    // then
+    await expect(page.getByRole('button', { name: "Weitere Einzelnorm"})).toHaveCount(0) 
+  })
+})

--- a/frontend/e2e/RubrikenPage/Verweise.spec.ts
+++ b/frontend/e2e/RubrikenPage/Verweise.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-test.describe('Verweise: Verwaltungsvorschrift', () => {
+test.describe('Verweise: Verwaltungsvorschrift und Norm', () => {
   test.beforeEach(async ({ page }) => {
     await page.route('/api/documentation-units/KSNR054920707', async (route) => {
       const json = {
@@ -12,7 +12,9 @@ test.describe('Verweise: Verwaltungsvorschrift', () => {
     })
   })
 
-  test('Do not show the button "Weitere Einzelnorm"', async ({ page }) => {
+  test('Do not show the button "Weitere Einzelnorm" if "Verwaltungsvorschrift" is selected', async ({
+    page,
+  }) => {
     // given
     await page.goto('/documentUnit/KSNR054920707/rubriken')
     await page.getByRole('radio', { name: 'Verwaltungsvorschrift auswä' }).click()
@@ -29,7 +31,29 @@ test.describe('Verweise: Verwaltungsvorschrift', () => {
     await page.getByRole('textbox', { name: 'Fassungsdatum der Norm' }).click()
     await page.getByRole('textbox', { name: 'Fassungsdatum der Norm' }).fill('12.12.2024')
     // then
-    await expect(page.getByRole('button', { name: "Weitere Einzelnorm"})).toHaveCount(0) 
+    await expect(page.getByRole('button', { name: 'Weitere Einzelnorm' })).toHaveCount(0)
+  })
+
+  test('Do show the button "Weitere Einzelnorm" if "Norm" is selected', async ({ page }) => {
+    // given
+    await page.goto('/documentUnit/KSNR054920707/rubriken')
+    await page.getByRole('textbox', { name: 'Art der Verweisung' }).click()
+    await page
+      .getByRole('button', { name: 'dropdown-option' })
+      .filter({ hasText: 'Anwendung' })
+      .click()
+    await page
+      .getByTestId('activeReferences')
+      .getByRole('textbox', { name: 'RIS-Abkürzung' })
+      .click()
+    await page
+      .getByRole('button', { name: 'dropdown-option' })
+      .filter({ hasText: 'SGB 5Sozialgesetzbuch (SGB) F' })
+      .click()
+    await page.getByRole('textbox', { name: 'Fassungsdatum der Norm' }).click()
+    await page.getByRole('textbox', { name: 'Fassungsdatum der Norm' }).fill('12.12.2024')
+    // then
+    await expect(page.getByRole('button', { name: 'Weitere Einzelnorm' })).toHaveCount(1)
   })
 
   // TODO: Show the button when a norm is selected

--- a/frontend/e2e/RubrikenPage/Verweise.spec.ts
+++ b/frontend/e2e/RubrikenPage/Verweise.spec.ts
@@ -55,6 +55,7 @@ test.describe('Verweise: Verwaltungsvorschrift und Norm', () => {
     await page.getByRole('textbox', { name: 'Fassungsdatum der Norm' }).fill('12.12.2024')
     // then
     await expect(page.getByRole('button', { name: 'Weitere Einzelnorm' })).toHaveCount(1)
+    await expect(page.getByRole('button', { name: 'Einzelnorm löschen' })).toHaveCount(1)
   })
 
   // TODO: remove the "x" when a ADM is selected, show the x when a norm is selected

--- a/frontend/e2e/RubrikenPage/Verweise.spec.ts
+++ b/frontend/e2e/RubrikenPage/Verweise.spec.ts
@@ -56,7 +56,5 @@ test.describe('Verweise: Verwaltungsvorschrift und Norm', () => {
     await expect(page.getByRole('button', { name: 'Weitere Einzelnorm' })).toHaveCount(1)
   })
 
-  // TODO: Show the button when a norm is selected
-
   // TODO: remove the "x" when a ADM is selected, show the x when a norm is selected
 })

--- a/frontend/e2e/RubrikenPage/Verweise.spec.ts
+++ b/frontend/e2e/RubrikenPage/Verweise.spec.ts
@@ -12,7 +12,7 @@ test.describe('Verweise: Verwaltungsvorschrift und Norm', () => {
     })
   })
 
-  test('Do not show the button "Weitere Einzelnorm" if "Verwaltungsvorschrift" is selected', async ({
+  test('Do not show the button "Weitere Einzelnorm", do not show the "x" for removal if "Verwaltungsvorschrift" is selected', async ({
     page,
   }) => {
     // given
@@ -32,6 +32,7 @@ test.describe('Verweise: Verwaltungsvorschrift und Norm', () => {
     await page.getByRole('textbox', { name: 'Fassungsdatum der Norm' }).fill('12.12.2024')
     // then
     await expect(page.getByRole('button', { name: 'Weitere Einzelnorm' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Einzelnorm löschen' })).toHaveCount(0)
   })
 
   test('Do show the button "Weitere Einzelnorm" if "Norm" is selected', async ({ page }) => {

--- a/frontend/e2e/RubrikenPage/Verweise.spec.ts
+++ b/frontend/e2e/RubrikenPage/Verweise.spec.ts
@@ -35,7 +35,7 @@ test.describe('Verweise: Verwaltungsvorschrift und Norm', () => {
     await expect(page.getByRole('button', { name: 'Einzelnorm löschen' })).toHaveCount(0)
   })
 
-  test('Do show the button "Weitere Einzelnorm" if "Norm" is selected', async ({ page }) => {
+  test('Do show the button "Weitere Einzelnorm" and the "x" for deletion if "Norm" is selected', async ({ page }) => {
     // given
     await page.goto('/documentUnit/KSNR054920707/rubriken')
     await page.getByRole('textbox', { name: 'Art der Verweisung' }).click()

--- a/frontend/e2e/RubrikenPage/Verweise.spec.ts
+++ b/frontend/e2e/RubrikenPage/Verweise.spec.ts
@@ -57,6 +57,4 @@ test.describe('Verweise: Verwaltungsvorschrift und Norm', () => {
     await expect(page.getByRole('button', { name: 'Weitere Einzelnorm' })).toHaveCount(1)
     await expect(page.getByRole('button', { name: 'Einzelnorm löschen' })).toHaveCount(1)
   })
-
-  // TODO: remove the "x" when a ADM is selected, show the x when a norm is selected
 })

--- a/frontend/src/components/ActiveReferenceInput.vue
+++ b/frontend/src/components/ActiveReferenceInput.vue
@@ -305,6 +305,10 @@ watch(
           <div>
             <div class="flex gap-24">
               <TextButton
+                v-if="
+                  activeReference.referenceDocumentType !==
+                  ActiveReferenceDocumentType.ADMINISTRATIVE_REGULATION
+                "
                 aria-label="Weitere Einzelnorm"
                 button-type="tertiary"
                 :icon="IconAdd"

--- a/frontend/src/components/SingleNormInput.vue
+++ b/frontend/src/components/SingleNormInput.vue
@@ -170,6 +170,7 @@ onMounted(async () => {
         />
       </InputField>
       <button
+        v-if="showSingleNormInput"
         aria-label="Einzelnorm löschen"
         class="mt-[25px] h-[50px] text-blue-800 focus:shadow-[inset_0_0_0_0.25rem] focus:shadow-blue-800 focus:outline-none"
         tabindex="0"


### PR DESCRIPTION
Also: introducing a possible way to organize e2e tests of a "page"