### PR TITLE
RISDEV-7028 Add endpoint for lookup-tables to fetch document types

### DIFF
--- a/backend/docker-initialization/create_tables.sql
+++ b/backend/docker-initialization/create_tables.sql
@@ -1,6 +1,6 @@
 set role lookup_tables;
 
-CREATE TABLE 
+CREATE TABLE
 IF NOT EXISTS
 lookup_tables.document_types (
     id uuid not null,
@@ -9,6 +9,7 @@ lookup_tables.document_types (
     constraint document_types_pkey primary key (id)
 );
 
-INSERT INTO lookup_tables.document_types VALUES ('8de5e4a0-6b67-4d65-98db-efe877a260c4', 'VR');
+INSERT INTO lookup_tables.document_types VALUES ('b678b77b-ffc4-4756-825d-a4376b985b0d', 'VE', 'Verwaltungsvereinbarung');
+INSERT INTO lookup_tables.document_types VALUES ('8de5e4a0-6b67-4d65-98db-efe877a260c4', 'VR', 'Verwaltungsregelung');
 
 set role test;

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentTypeController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentTypeController.java
@@ -14,7 +14,11 @@ public class DocumentTypeController {
   private final LookupTablesPort lookupTablesPort;
 
   @GetMapping("api/lookup-tables/document-types")
-  public ResponseEntity<DocumentTypeResponse> getDocumentTypes(@RequestParam(required = false) String searchQuery) {
-    return ResponseEntity.ok(new DocumentTypeResponse(lookupTablesPort.findBySearchQuery(searchQuery)));
+  public ResponseEntity<DocumentTypeResponse> getDocumentTypes(
+    @RequestParam(required = false) String searchQuery
+  ) {
+    return ResponseEntity.ok(
+      new DocumentTypeResponse(lookupTablesPort.findBySearchQuery(searchQuery))
+    );
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentTypeController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentTypeController.java
@@ -1,20 +1,20 @@
 package de.bund.digitalservice.ris.adm_vwv.adapter.api;
 
-import de.bund.digitalservice.ris.adm_vwv.application.DocumentType;
-import java.util.List;
+import de.bund.digitalservice.ris.adm_vwv.application.LookupTablesPort;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class DocumentTypeController {
 
+  private final LookupTablesPort lookupTablesPort;
+
   @GetMapping("api/lookup-tables/document-types")
-  public ResponseEntity<List<DocumentType>> getDocumentTypes() {
-    var dokumentTypList = List.of(
-      new DocumentType("VE", "Verwaltungsvereinbarung"),
-      new DocumentType("VR", "Verwaltungsregelung")
-    );
-    return ResponseEntity.ok(dokumentTypList);
+  public ResponseEntity<DocumentTypeResponse> getDocumentTypes(@RequestParam(required = false) String searchQuery) {
+    return ResponseEntity.ok(new DocumentTypeResponse(lookupTablesPort.findBySearchQuery(searchQuery)));
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentTypeResponse.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentTypeResponse.java
@@ -1,0 +1,7 @@
+package de.bund.digitalservice.ris.adm_vwv.adapter.api;
+
+import de.bund.digitalservice.ris.adm_vwv.application.DocumentType;
+
+import java.util.List;
+
+public record DocumentTypeResponse(List<DocumentType> documentTypes){}

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentTypeResponse.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentTypeResponse.java
@@ -1,7 +1,6 @@
 package de.bund.digitalservice.ris.adm_vwv.adapter.api;
 
 import de.bund.digitalservice.ris.adm_vwv.application.DocumentType;
-
 import java.util.List;
 
-public record DocumentTypeResponse(List<DocumentType> documentTypes){}
+public record DocumentTypeResponse(List<DocumentType> documentTypes) {}

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentTypeEntity.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentTypeEntity.java
@@ -1,0 +1,21 @@
+package de.bund.digitalservice.ris.adm_vwv.adapter.persistence;
+
+import jakarta.persistence.*;
+import java.util.UUID;
+import lombok.Data;
+
+/**
+ * Document type entity.
+ */
+@Entity
+@Data
+@Table(name = "document_types_view")
+public class DocumentTypeEntity {
+
+  @Id
+  private UUID id;
+
+  private String abbreviation;
+
+  private String name;
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentTypesRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentTypesRepository.java
@@ -1,0 +1,11 @@
+package de.bund.digitalservice.ris.adm_vwv.adapter.persistence;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface DocumentTypesRepository extends JpaRepository<DocumentTypeEntity, UUID> {
+  List<DocumentTypeEntity> findByAbbreviationLikeIgnoreCaseOrNameLikeIgnoreCase(
+    String abbreviation, String name
+  );
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentTypesRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentTypesRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 interface DocumentTypesRepository extends JpaRepository<DocumentTypeEntity, UUID> {
   List<DocumentTypeEntity> findByAbbreviationLikeIgnoreCaseOrNameLikeIgnoreCase(
-    String abbreviation, String name
+    String abbreviation,
+    String name
   );
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentTypesRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentTypesRepository.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 interface DocumentTypesRepository extends JpaRepository<DocumentTypeEntity, UUID> {
-  List<DocumentTypeEntity> findByAbbreviationLikeIgnoreCaseOrNameLikeIgnoreCase(
+  List<DocumentTypeEntity> findByAbbreviationContainingIgnoreCaseOrNameContainingIgnoreCase(
     String abbreviation,
     String name
   );

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/LookupTablesPersistenceService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/LookupTablesPersistenceService.java
@@ -5,7 +5,7 @@ import de.bund.digitalservice.ris.adm_vwv.application.LookupTablesPersistencePor
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,9 +16,15 @@ public class LookupTablesPersistenceService implements LookupTablesPersistencePo
   private final DocumentTypesRepository documentTypesRepository;
 
   @Override
-  public List<DocumentType> findBySearchQuery(@NotNull String searchQuery) {
-    return documentTypesRepository
-      .findByAbbreviationLikeIgnoreCaseOrNameLikeIgnoreCase(searchQuery, searchQuery)
+  public List<DocumentType> findBySearchQuery(String searchQuery) {
+    List<DocumentTypeEntity> documentTypes = StringUtils.isBlank(searchQuery)
+      ? documentTypesRepository.findAll()
+      : documentTypesRepository.findByAbbreviationContainingIgnoreCaseOrNameContainingIgnoreCase(
+        searchQuery,
+        searchQuery
+      );
+
+    return documentTypes
       .stream()
       .map(x -> new DocumentType(x.getAbbreviation(), x.getName()))
       .toList();

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/LookupTablesPersistenceService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/LookupTablesPersistenceService.java
@@ -1,0 +1,26 @@
+package de.bund.digitalservice.ris.adm_vwv.adapter.persistence;
+
+import de.bund.digitalservice.ris.adm_vwv.application.DocumentType;
+import de.bund.digitalservice.ris.adm_vwv.application.LookupTablesPersistencePort;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class LookupTablesPersistenceService implements LookupTablesPersistencePort {
+
+  private final DocumentTypesRepository documentTypesRepository;
+
+  @Override
+  public List<DocumentType> findBySearchQuery(@NotNull String searchQuery) {
+    return documentTypesRepository
+      .findByAbbreviationLikeIgnoreCaseOrNameLikeIgnoreCase(searchQuery, searchQuery)
+      .stream()
+      .map(x -> new DocumentType(x.getAbbreviation(), x.getName()))
+      .toList();
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesPersistencePort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesPersistencePort.java
@@ -1,0 +1,8 @@
+package de.bund.digitalservice.ris.adm_vwv.application;
+
+import jakarta.annotation.Nonnull;
+import java.util.List;
+
+public interface LookupTablesPersistencePort {
+  List<DocumentType> findBySearchQuery(@Nonnull String searchQuery);
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesPersistencePort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesPersistencePort.java
@@ -1,8 +1,7 @@
 package de.bund.digitalservice.ris.adm_vwv.application;
 
-import jakarta.annotation.Nonnull;
 import java.util.List;
 
 public interface LookupTablesPersistencePort {
-  List<DocumentType> findBySearchQuery(@Nonnull String searchQuery);
+  List<DocumentType> findBySearchQuery(String searchQuery);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesPort.java
@@ -1,0 +1,8 @@
+package de.bund.digitalservice.ris.adm_vwv.application;
+
+import jakarta.annotation.Nonnull;
+import java.util.List;
+
+public interface LookupTablesPort {
+  List<DocumentType> findBySearchQuery(@Nonnull String searchQuery);
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesPort.java
@@ -1,8 +1,7 @@
 package de.bund.digitalservice.ris.adm_vwv.application;
 
-import jakarta.annotation.Nonnull;
 import java.util.List;
 
 public interface LookupTablesPort {
-  List<DocumentType> findBySearchQuery(@Nonnull String searchQuery);
+  List<DocumentType> findBySearchQuery(String searchQuery);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesService.java
@@ -1,6 +1,5 @@
 package de.bund.digitalservice.ris.adm_vwv.application;
 
-import jakarta.annotation.Nonnull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,7 +11,7 @@ public class LookupTablesService implements LookupTablesPort {
   private final LookupTablesPersistencePort lookupTablesPersistencePort;
 
   @Override
-  public List<DocumentType> findBySearchQuery(@Nonnull String searchQuery) {
+  public List<DocumentType> findBySearchQuery(String searchQuery) {
     return lookupTablesPersistencePort.findBySearchQuery(searchQuery);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesService.java
@@ -1,0 +1,19 @@
+package de.bund.digitalservice.ris.adm_vwv.application;
+
+import de.bund.digitalservice.ris.adm_vwv.adapter.persistence.LookupTablesPersistenceService;
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LookupTablesService implements LookupTablesPort {
+
+  private final LookupTablesPersistencePort lookupTablesPersistencePort;
+
+  @Override
+  public List<DocumentType> findBySearchQuery(@Nonnull String searchQuery) {
+    return lookupTablesPersistencePort.findBySearchQuery(searchQuery);
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesService.java
@@ -1,6 +1,5 @@
 package de.bund.digitalservice.ris.adm_vwv.application;
 
-import de.bund.digitalservice.ris.adm_vwv.adapter.persistence.LookupTablesPersistenceService;
 import jakarta.annotation.Nonnull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentTypeControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentTypeControllerTest.java
@@ -1,15 +1,20 @@
 package de.bund.digitalservice.ris.adm_vwv.adapter.api;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import de.bund.digitalservice.ris.adm_vwv.application.DocumentType;
+import de.bund.digitalservice.ris.adm_vwv.application.LookupTablesPort;
 import de.bund.digitalservice.ris.adm_vwv.config.SecurityConfiguration;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = DocumentTypeController.class)
@@ -19,20 +24,30 @@ class DocumentTypeControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
+  @MockitoBean
+  private LookupTablesPort lookupTablesPort;
+
   @Test
   @DisplayName("GET returns HTTP 200 and a JSON with two documentTypes with abbreviation and name")
   void getDocumentTypes() throws Exception {
     // given
+    String searchQuery = "verwaltungs";
+    given(lookupTablesPort.findBySearchQuery(searchQuery)).willReturn(
+      List.of(
+        new DocumentType("VE", "Verwaltungsvereinbarung"),
+        new DocumentType("VR", "Verwaltungsregelung")
+      )
+    );
 
     // when
     mockMvc
-      .perform(get("/api/lookup-tables/document-types"))
+      .perform(get("/api/lookup-tables/document-types").param("searchQuery", searchQuery))
       // then
       .andExpect(content().contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.[0].abbreviation").value("VE"))
-      .andExpect(jsonPath("$.[0].name").value("Verwaltungsvereinbarung"))
-      .andExpect(jsonPath("$.[1].abbreviation").value("VR"))
-      .andExpect(jsonPath("$.[1].name").value("Verwaltungsregelung"));
+      .andExpect(jsonPath("$.documentTypes[0].abbreviation").value("VE"))
+      .andExpect(jsonPath("$.documentTypes[0].name").value("Verwaltungsvereinbarung"))
+      .andExpect(jsonPath("$.documentTypes[1].abbreviation").value("VR"))
+      .andExpect(jsonPath("$.documentTypes[1].name").value("Verwaltungsregelung"));
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/LookupTablesPersistenceServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/LookupTablesPersistenceServiceTest.java
@@ -1,0 +1,58 @@
+package de.bund.digitalservice.ris.adm_vwv.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import de.bund.digitalservice.ris.adm_vwv.application.DocumentType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig
+class LookupTablesPersistenceServiceTest {
+
+  @InjectMocks
+  private LookupTablesPersistenceService lookupTablesPersistenceService;
+
+  @Mock
+  private DocumentTypesRepository documentTypesRepository;
+
+  @Test
+  void findBySearchQuery_all() {
+    // given
+    DocumentTypeEntity documentTypeEntity = new DocumentTypeEntity();
+    documentTypeEntity.setAbbreviation("VR");
+    documentTypeEntity.setName("Verwaltungsregelung");
+    given(documentTypesRepository.findAll()).willReturn(List.of(documentTypeEntity));
+
+    // when
+    List<DocumentType> documentTypes = lookupTablesPersistenceService.findBySearchQuery(null);
+
+    // then
+    assertThat(documentTypes).contains(new DocumentType("VR", "Verwaltungsregelung"));
+  }
+
+  @Test
+  void findBySearchQuery_something() {
+    // given
+    DocumentTypeEntity documentTypeEntity = new DocumentTypeEntity();
+    documentTypeEntity.setAbbreviation("VR");
+    documentTypeEntity.setName("Verwaltungsregelung");
+    given(
+      documentTypesRepository.findByAbbreviationContainingIgnoreCaseOrNameContainingIgnoreCase(
+        "something",
+        "something"
+      )
+    ).willReturn(List.of(documentTypeEntity));
+
+    // when
+    List<DocumentType> documentTypes = lookupTablesPersistenceService.findBySearchQuery(
+      "something"
+    );
+
+    // then
+    assertThat(documentTypes).contains(new DocumentType("VR", "Verwaltungsregelung"));
+  }
+}


### PR DESCRIPTION
- without query param: returns all entries
- with searchQuery it filters with LIKE %QUERY% method