### PR TITLE
Use istanbul for code coverage report generation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -67,6 +67,7 @@
         "@testing-library/vue": "^8.1.0",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^22.13.14",
+        "@vitest/coverage-istanbul": "^3.1.1",
         "@vitest/coverage-v8": "^3.1.1",
         "@vitest/eslint-plugin": "1.1.38",
         "@vitest/ui": "^3.1.1",
@@ -3702,6 +3703,31 @@
         "vue": "^3.0.0"
       }
     },
+    "node_modules/@vitest/coverage-istanbul": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-3.1.1.tgz",
+      "integrity": "sha512-uSoMeVcF5fMGcjWJOeG28nBPO2OuCNMRr+BcpF71gc1r/+EQnU7EeRM1hihs3EsSAOcjgw9w+TCMv/2lVvB4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.3",
+        "debug": "^4.4.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-instrument": "^6.0.3",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magicast": "^0.3.5",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.1.1"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.1.tgz",
@@ -7158,6 +7184,36 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-report": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -68,7 +68,6 @@
         "@types/jsdom": "^21.1.7",
         "@types/node": "^22.13.14",
         "@vitest/coverage-istanbul": "^3.1.1",
-        "@vitest/coverage-v8": "^3.1.1",
         "@vitest/eslint-plugin": "1.1.38",
         "@vitest/ui": "^3.1.1",
         "@vue/eslint-config-prettier": "^10.2.0",
@@ -603,16 +602,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bcoe/v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -3726,49 +3715,6 @@
       },
       "peerDependencies": {
         "vitest": "3.1.1"
-      }
-    },
-    "node_modules/@vitest/coverage-v8": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.1.tgz",
-      "integrity": "sha512-MgV6D2dhpD6Hp/uroUoAIvFqA8AuvXEFBC2eepG3WFc1pxTfdk1LEqqkWoWhjz+rytoqrnUUCdf6Lzco3iHkLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
-        "@bcoe/v8-coverage": "^1.0.2",
-        "debug": "^4.4.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
-        "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.17",
-        "magicast": "^0.3.5",
-        "std-env": "^3.8.1",
-        "test-exclude": "^7.0.1",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "3.1.1",
-        "vitest": "3.1.1"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/@vitest/eslint-plugin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "postcss-import": "^16.1.0",
     "primevue": "^4.3.3",
     "tailwindcss": "^3.4.17",
+    8
     "unplugin-icons": "^22.1.0",
     "vite": "^6.2.5",
     "vite-plugin-vue-devtools": "^7.7.2",
@@ -83,7 +84,6 @@
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.13.14",
     "@vitest/coverage-istanbul": "^3.1.1",
-    "@vitest/coverage-v8": "^3.1.1",
     "@vitest/eslint-plugin": "1.1.38",
     "@vitest/ui": "^3.1.1",
     "@vue/eslint-config-prettier": "^10.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -82,6 +82,7 @@
     "@testing-library/vue": "^8.1.0",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.13.14",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@vitest/coverage-v8": "^3.1.1",
     "@vitest/eslint-plugin": "1.1.38",
     "@vitest/ui": "^3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,7 +67,6 @@
     "postcss-import": "^16.1.0",
     "primevue": "^4.3.3",
     "tailwindcss": "^3.4.17",
-    8
     "unplugin-icons": "^22.1.0",
     "vite": "^6.2.5",
     "vite-plugin-vue-devtools": "^7.7.2",

--- a/frontend/src/components/field-of-law/FieldsOfLaw.spec.ts
+++ b/frontend/src/components/field-of-law/FieldsOfLaw.spec.ts
@@ -37,7 +37,7 @@ function renderComponent() {
   }
 }
 
-describe.skip('FieldsOfLaw', () => {
+describe('FieldsOfLaw', () => {
   const getChildrenOfRoot = () =>
     Promise.resolve({
       status: 200,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -18,7 +18,7 @@ export default mergeConfig(
         json: './frontend-unit-test-report.json',
       },
       coverage: {
-        provider: 'v8',
+        provider: 'istanbul',
         reporter: ['lcov', 'text', 'html'],
         // Changes to this also need to be reflected in the sonar-project.properties
         exclude: [


### PR DESCRIPTION
There does not seem to be a time penalty for switching coverage tools:
  * Code coverage with istanbul: 33s ([link](https://github.com/digitalservicebund/ris-adm-vwv/actions/runs/14242332339/job/39914927712?pr=394))
  * Code coverage with v8: 35s ([link](https://github.com/digitalservicebund/ris-adm-vwv/actions/runs/14216328647/job/39833821441))
  
On the sonar report on the PR, you'll find a [warning](https://community.sonarsource.com/t/parsing-error-reported-but-cant-find-any-trace-in-the-log/138205) which I understand to be an error on their side (on the community forum someone told me [he would forward it to the devs](https://community.sonarsource.com/t/parsing-error-reported-but-cant-find-any-trace-in-the-log/138205/2?u=hannes)).