### PR TITLE
Use istanbul for code coverage report generation (#394)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -67,6 +67,7 @@
         "@testing-library/vue": "^8.1.0",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^22.14.0",
+        "@vitest/coverage-istanbul": "^3.1.1",
         "@vitest/coverage-v8": "^3.1.1",
         "@vitest/eslint-plugin": "1.1.39",
         "@vitest/ui": "^3.1.1",
@@ -3702,6 +3703,31 @@
         "vue": "^3.0.0"
       }
     },
+    "node_modules/@vitest/coverage-istanbul": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-3.1.1.tgz",
+      "integrity": "sha512-uSoMeVcF5fMGcjWJOeG28nBPO2OuCNMRr+BcpF71gc1r/+EQnU7EeRM1hihs3EsSAOcjgw9w+TCMv/2lVvB4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.3",
+        "debug": "^4.4.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-instrument": "^6.0.3",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magicast": "^0.3.5",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.1.1"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.1.tgz",
@@ -7158,6 +7184,36 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-report": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -82,6 +82,7 @@
     "@testing-library/vue": "^8.1.0",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.14.0",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@vitest/coverage-v8": "^3.1.1",
     "@vitest/eslint-plugin": "1.1.39",
     "@vitest/ui": "^3.1.1",

--- a/frontend/src/components/field-of-law/FieldsOfLaw.spec.ts
+++ b/frontend/src/components/field-of-law/FieldsOfLaw.spec.ts
@@ -37,7 +37,7 @@ function renderComponent() {
   }
 }
 
-describe.skip('FieldsOfLaw', () => {
+describe('FieldsOfLaw', () => {
   const getChildrenOfRoot = () =>
     Promise.resolve({
       status: 200,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -33,6 +33,9 @@ export default mergeConfig(
           '**/*.d.ts',
           'src/components/input/types.ts',
 
+          // Assets
+          'html/assets/*',
+
           // Tests
           '**/*.spec.ts',
           'e2e/**/*',

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -18,7 +18,7 @@ export default mergeConfig(
         json: './frontend-unit-test-report.json',
       },
       coverage: {
-        provider: 'v8',
+        provider: 'istanbul',
         reporter: ['lcov', 'text', 'html'],
         // Changes to this also need to be reflected in the sonar-project.properties
         exclude: [


### PR DESCRIPTION
* Use istanbul for code coverage report generation
* Remove coverage-v8
* Enable tests on FieldsOfLaw component
