### PR TITLE
RISDEV-7761 Add Kurzreferat transformer

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterService.java
@@ -4,8 +4,9 @@ import de.bund.digitalservice.ris.adm_vwv.application.DocumentationUnit;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.business.DocumentationUnitContent;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.AkomaNtoso;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.transform.EntryIntoEffectDateTransformer;
-import de.bund.digitalservice.ris.adm_vwv.application.converter.transform.ExpirationDateTransformer;
+import de.bund.digitalservice.ris.adm_vwv.application.converter.transform.ExpiryDateTransformer;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.transform.FundstellenTransformer;
+import de.bund.digitalservice.ris.adm_vwv.application.converter.transform.KurzreferatTransformer;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.transform.LongTitleTransformer;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -42,9 +43,9 @@ public class LdmlConverterService {
       List.of(),
       null,
       new EntryIntoEffectDateTransformer(akomaNtoso).transform(),
-      new ExpirationDateTransformer(akomaNtoso).transform(),
+      new ExpiryDateTransformer(akomaNtoso).transform(),
       null,
-      null,
+      new KurzreferatTransformer(akomaNtoso).transform(),
       List.of(),
       null,
       null,

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlWriter.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlWriter.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.adm_vwv.application.converter;
 
 import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.AkomaNtoso;
+import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.JaxbHtml;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
@@ -15,15 +16,28 @@ import lombok.extern.slf4j.Slf4j;
 public class XmlWriter {
 
   /**
-   * Transforms a JAXb element into a string.
+   * Transforms a JAXb element into a string. The output contains an XML header node.
    * @param jaxbElement The JAXb element to transform
    * @return String representation of the given JAXB element
    */
   public String writeXml(@Nonnull Object jaxbElement) {
+    return writeXml(jaxbElement, true);
+  }
+
+  /**
+   * Transforms a JAXb element into a string.
+   * @param jaxbElement The JAXb element to transform
+   * @param includeHeader If set to {@code true}, then the output contains an XML header node, otherwise set to
+   *                      {@code false}
+   * @return String representation of the given JAXB element
+   */
+  public String writeXml(@Nonnull Object jaxbElement, boolean includeHeader) {
     try {
-      JAXBContext jaxbContext = JAXBContext.newInstance(AkomaNtoso.class);
+      // Create JAXB instance with all possible root elements
+      JAXBContext jaxbContext = JAXBContext.newInstance(AkomaNtoso.class, JaxbHtml.class);
       Marshaller marshaller = jaxbContext.createMarshaller();
       marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+      marshaller.setProperty(Marshaller.JAXB_FRAGMENT, !includeHeader);
       StringWriter stringWriter = new StringWriter();
       marshaller.marshal(jaxbElement, stringWriter);
       return stringWriter.toString();

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/ldml/RisMetadata.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/ldml/RisMetadata.java
@@ -25,7 +25,7 @@ public class RisMetadata {
   private String entryIntoEffectDate;
 
   @XmlElement(namespace = XmlNamespace.RIS_NS)
-  private String expirationDate;
+  private String expiryDate;
 
   @XmlElement(namespace = XmlNamespace.RIS_NS)
   private RisDocumentType documentType;

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/ExpiryDateTransformer.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/ExpiryDateTransformer.java
@@ -7,22 +7,22 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 /**
- * ExpirationDate transformer.
+ * Expiry date transformer.
  */
 @RequiredArgsConstructor
-public class ExpirationDateTransformer {
+public class ExpiryDateTransformer {
 
   private final AkomaNtoso akomaNtoso;
 
   /**
-   * Transforms the {@code ExpirationDate} object to a string.
+   * Transforms the {@code ExpiryDate} object to a string.
    *
-   * @return The expirationDate or null if Proprietary or Metadata does not exist
+   * @return The expiryDate or null if Proprietary or Metadata does not exist
    */
   public String transform() {
     return Optional.ofNullable(akomaNtoso.getDoc().getMeta().getProprietary())
       .map(Proprietary::getMetadata)
-      .map(RisMetadata::getExpirationDate)
+      .map(RisMetadata::getExpiryDate)
       .orElse(null);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformer.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformer.java
@@ -1,0 +1,36 @@
+package de.bund.digitalservice.ris.adm_vwv.application.converter.transform;
+
+import de.bund.digitalservice.ris.adm_vwv.application.converter.XmlWriter;
+import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.AkomaNtoso;
+import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.JaxbHtml;
+import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.MainBody;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Kurzreferat transformer.
+ */
+@RequiredArgsConstructor
+public class KurzreferatTransformer {
+
+  private final AkomaNtoso akomaNtoso;
+  private final XmlWriter xmlWriter = new XmlWriter();
+
+  /**
+   * Transforms the {@code AkomaNtoso} object to a 'Kurzreferat' HTML string.
+   *
+   * @return The 'Kurzreferat' HTML, or {@code null} if the surrounding {@code <mainBody>} element is {@code null}.
+   */
+  public String transform() {
+    MainBody mainBody = akomaNtoso.getDoc().getMainBody();
+    if (mainBody == null) {
+      return null;
+    }
+    JaxbHtml div = mainBody.getDiv();
+    return xmlWriter
+      .writeXml(div, false)
+      // Replace wrapper element completely
+      .replaceAll("</?jaxbHtml.*>", "")
+      // Remove akn prefix from tag names, e.g. <akn:p> is transformed to <p>
+      .replaceAll("<(/?)akn:([^<]*)>", "<$1$2>");
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterServiceTest.java
@@ -1,12 +1,13 @@
 package de.bund.digitalservice.ris.adm_vwv.application.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import de.bund.digitalservice.ris.adm_vwv.application.DocumentationUnit;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.business.DocumentationUnitContent;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.business.Reference;
+import de.bund.digitalservice.ris.adm_vwv.test.TestFile;
 import java.util.UUID;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
@@ -17,18 +18,7 @@ class LdmlConverterServiceTest {
   @Test
   void convertToBusinessModel() {
     // given
-    String xml =
-      """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <akn:akomaNtoso
-        xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
-        xmlns:ris="http://ldml.neuris.de/metadata/">
-        <akn:doc name="offene-struktur">
-          <akn:meta>
-          </akn:meta>
-        </akn:doc>
-      </akn:akomaNtoso>
-      """;
+    String xml = TestFile.readFileToString("ldml-example.akn.xml");
     UUID uuid = UUID.randomUUID();
     DocumentationUnit documentationUnit = new DocumentationUnit("KSNR20250000001", uuid, null, xml);
 
@@ -47,23 +37,7 @@ class LdmlConverterServiceTest {
   @Test
   void convertToBusinessModel_fundstellen() {
     // given
-    String xml =
-      """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <akn:akomaNtoso
-        xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
-        xmlns:ris="http://ldml.neuris.de/metadata/">
-        <akn:doc name="offene-struktur">
-          <akn:meta>
-            <akn:analysis>
-              <akn:otherReferences>
-                  <akn:implicitReference showAs="2020, Seite 5" shortForm="BAnz" />
-              </akn:otherReferences>
-            </akn:analysis>
-          </akn:meta>
-        </akn:doc>
-      </akn:akomaNtoso>
-      """;
+    String xml = TestFile.readFileToString("ldml-example.akn.xml");
     DocumentationUnit documentationUnit = new DocumentationUnit(
       "KSNR20250000001",
       UUID.randomUUID(),
@@ -82,28 +56,13 @@ class LdmlConverterServiceTest {
       .extracting(DocumentationUnitContent::references)
       .asInstanceOf(InstanceOfAssertFactories.list(Reference.class))
       .extracting(Reference::citation, Reference::legalPeriodicalRawValue)
-      .containsOnly(Assertions.tuple("2020, Seite 5", "BAnz"));
+      .containsOnly(tuple("Das Periodikum 2021, Seite 15", "Das Periodikum"));
   }
 
   @Test
   void convertToBusinessModel_longTitle() {
     // given
-    String xml =
-      """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <akn:akomaNtoso
-        xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
-        xmlns:ris="http://ldml.neuris.de/metadata/">
-        <akn:doc name="offene-struktur">
-          <akn:meta></akn:meta>
-          <akn:preface>
-            <akn:longTitle>
-              <akn:block name="longTitle">Langer Titel</akn:block>
-            </akn:longTitle>
-          </akn:preface>
-        </akn:doc>
-      </akn:akomaNtoso>
-      """;
+    String xml = TestFile.readFileToString("ldml-example.akn.xml");
     DocumentationUnit documentationUnit = new DocumentationUnit(
       "KSNR20250000001",
       UUID.randomUUID(),
@@ -120,29 +79,35 @@ class LdmlConverterServiceTest {
     assertThat(documentationUnitContent)
       .isNotNull()
       .extracting(DocumentationUnitContent::langueberschrift)
-      .isEqualTo("Langer Titel");
+      .isEqualTo("1. Bekanntmachung zum XML-Testen in NeuRIS VwV");
+  }
+
+  @Test
+  void convertToBusinessModel_kurzreferat() {
+    // given
+    String xml = TestFile.readFileToString("ldml-example.akn.xml");
+    DocumentationUnit documentationUnit = new DocumentationUnit(
+      "KSNR20250000001",
+      UUID.randomUUID(),
+      null,
+      xml
+    );
+
+    // when
+    DocumentationUnitContent documentationUnitContent = ldmlConverterService.convertToBusinessModel(
+      documentationUnit
+    );
+
+    // then
+    assertThat(documentationUnitContent.kurzreferat())
+      .isNotNull()
+      .containsSubsequence("<p>Kurzreferat Zeile 1</p>", "<p>Kurzreferat Zeile 2</p>");
   }
 
   @Test
   void convertToBusinessModel_entryIntoEffectDate() {
     // given
-    String xml =
-      """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <akn:akomaNtoso
-        xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
-        xmlns:ris="http://ldml.neuris.de/metadata/">
-        <akn:doc name="offene-struktur">
-          <akn:meta>
-            <akn:proprietary source="attributsemantik-noch-undefiniert">
-              <ris:metadata>
-                <ris:entryIntoEffectDate>2025-01-01</ris:entryIntoEffectDate>
-              </ris:metadata>
-            </akn:proprietary>
-          </akn:meta>
-        </akn:doc>
-      </akn:akomaNtoso>
-      """;
+    String xml = TestFile.readFileToString("ldml-example.akn.xml");
     DocumentationUnit documentationUnit = new DocumentationUnit(
       "KSNR20250000001",
       UUID.randomUUID(),
@@ -165,23 +130,7 @@ class LdmlConverterServiceTest {
   @Test
   void convertToBusinessModel_expirationDate() {
     // given
-    String xml =
-      """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <akn:akomaNtoso
-        xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
-        xmlns:ris="http://ldml.neuris.de/metadata/">
-        <akn:doc name="offene-struktur">
-          <akn:meta>
-            <akn:proprietary source="attributsemantik-noch-undefiniert">
-              <ris:metadata>
-                <ris:expirationDate>2025-02-02</ris:expirationDate>
-              </ris:metadata>
-            </akn:proprietary>
-          </akn:meta>
-        </akn:doc>
-      </akn:akomaNtoso>
-      """;
+    String xml = TestFile.readFileToString("ldml-example.akn.xml");
     DocumentationUnit documentationUnit = new DocumentationUnit(
       "KSNR20250000001",
       UUID.randomUUID(),

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterServiceTest.java
@@ -128,7 +128,7 @@ class LdmlConverterServiceTest {
   }
 
   @Test
-  void convertToBusinessModel_expirationDate() {
+  void convertToBusinessModel_expiryDate() {
     // given
     String xml = TestFile.readFileToString("ldml-example.akn.xml");
     DocumentationUnit documentationUnit = new DocumentationUnit(

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlWriterTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlWriterTest.java
@@ -49,6 +49,41 @@ class XmlWriterTest {
   }
 
   @Test
+  void writeXml_withoutXmlHeader() {
+    // given
+    AkomaNtoso akomaNtoso = new AkomaNtoso();
+    Doc doc = new Doc();
+    Preface preface = new Preface();
+    LongTitle longTitle = new LongTitle();
+    JaxbHtml block = new JaxbHtml();
+    block.setName("longTitle");
+    block.setHtml(List.of("Noch längerer Titel"));
+    longTitle.setBlock(block);
+    preface.setLongTitle(longTitle);
+    doc.setPreface(preface);
+    akomaNtoso.setDoc(doc);
+
+    // when
+    String xml = xmlWriter.writeXml(akomaNtoso, false);
+
+    // then
+    assertThat(xml)
+      .isNotNull()
+      .isEqualTo(
+        """
+        <akn:akomaNtoso xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:ris="http://ldml.neuris.de/metadata/">
+            <akn:doc name="offene-struktur">
+                <akn:preface>
+                    <akn:longTitle>
+                        <akn:block name="longTitle">Noch längerer Titel</akn:block>
+                    </akn:longTitle>
+                </akn:preface>
+            </akn:doc>
+        </akn:akomaNtoso>"""
+      );
+  }
+
+  @Test
   void writeXml_exceptionDueToNonRootElement() {
     // given
     Doc doc = new Doc();

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformerTest.java
@@ -1,0 +1,50 @@
+package de.bund.digitalservice.ris.adm_vwv.application.converter.transform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.*;
+import jakarta.xml.bind.JAXBElement;
+import java.util.List;
+import javax.xml.namespace.QName;
+import org.junit.jupiter.api.Test;
+
+class KurzreferatTransformerTest {
+
+  @Test
+  void transform() {
+    // given
+    AkomaNtoso akomaNtoso = new AkomaNtoso();
+    Doc doc = new Doc();
+    akomaNtoso.setDoc(doc);
+    MainBody mainBody = new MainBody();
+    doc.setMainBody(mainBody);
+    JaxbHtml div = new JaxbHtml();
+    div.setHtml(List.of("Langer Titel"));
+    mainBody.setDiv(div);
+    JAXBElement<String> line1 = new JAXBElement<>(QName.valueOf("akn:p"), String.class, "Zeile 1");
+    JAXBElement<String> line2 = new JAXBElement<>(QName.valueOf("akn:p"), String.class, "Zeile 2");
+    div.setHtml(List.of(line1, line2));
+
+    // when
+    String actualKurzreferat = new KurzreferatTransformer(akomaNtoso).transform();
+
+    // then
+    assertThat(actualKurzreferat).containsSubsequence("<p>Zeile 1</p>", "<p>Zeile 2</p>");
+  }
+
+  @Test
+  void transform_noMainBodyElement() {
+    // given
+    AkomaNtoso akomaNtoso = new AkomaNtoso();
+    Doc doc = new Doc();
+    akomaNtoso.setDoc(doc);
+    Meta meta = new Meta();
+    doc.setMeta(meta);
+
+    // when
+    String actualKurzreferat = new KurzreferatTransformer(akomaNtoso).transform();
+
+    // then
+    assertThat(actualKurzreferat).isNull();
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/test/TestFile.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/test/TestFile.java
@@ -1,0 +1,35 @@
+package de.bund.digitalservice.ris.adm_vwv.test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Class for reading files for testing purposes.
+ */
+@UtilityClass
+public class TestFile {
+
+  /**
+   * Reads the given filename and returns a string which its contents. The file must be located on the classpath.
+   * @param name The filename
+   * @return Content of the given filename
+   */
+  public static String readFileToString(String name) {
+    try {
+      URL resource = TestFile.class.getClassLoader().getResource(name);
+      if (resource == null) {
+        throw new FileNotFoundException(name);
+      }
+      Path path = Path.of(resource.toURI());
+      return Files.readString(path, StandardCharsets.UTF_8);
+    } catch (IOException | URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/backend/src/test/resources/ldml-example.akn.xml
+++ b/backend/src/test/resources/ldml-example.akn.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akn:akomaNtoso
+  xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+  xmlns:ris="http://ldml.neuris.de/metadata/">
+  <akn:doc name="offene-struktur">
+    <akn:meta>
+      <akn:identification source="attributsemantik-noch-undefiniert">
+        <!-- omitted -->
+      </akn:identification>
+      <akn:classification source="attributsemantik-noch-undefiniert">
+        <akn:keyword showAs="Schlag" dictionary="attributsemantik-noch-undefiniert" value="Schlag"/>
+        <akn:keyword showAs="Wort" dictionary="attributsemantik-noch-undefiniert" value="Wort"/>
+        <akn:keyword showAs="Mehrere Wörter in einem Schlagwort" dictionary="attributsemantik-noch-undefiniert"
+                     value="Mehrere Wörter in einem Schlagwort"/>
+      </akn:classification>
+      <akn:analysis source="attributsemantik-noch-undefiniert">
+        <akn:otherReferences source="attributsemantik-noch-undefiniert">
+          <akn:implicitReference shortForm="Das Periodikum" showAs="Das Periodikum 2021, Seite 15"/>
+        </akn:otherReferences>
+        <akn:otherReferences source="attributsemantik-noch-undefiniert">
+          <akn:implicitReference shortForm="PhanGB" showAs="PhanGB § 1a Abs 1">
+            <ris:normReference singleNorm="§ 1a Abs 1"/>
+          </akn:implicitReference>
+        </akn:otherReferences>
+        <akn:otherReferences source="attributsemantik-noch-undefiniert">
+          <akn:implicitReference shortForm="PhanGB" showAs="PhanGB 5 § 2 Abs 6">
+            <ris:normReference singleNorm="§ 2 Abs 6"/>
+          </akn:implicitReference>
+        </akn:otherReferences>
+      </akn:analysis>
+      <akn:proprietary source="attributsemantik-noch-undefiniert">
+        <ris:metadata>
+          <ris:normgeber staat="DS"/>
+          <ris:fieldsOfLaw>
+            <ris:fieldOfLaw notation="neu">PR-05-01</ris:fieldOfLaw>
+            <ris:fieldOfLaw notation="neu">XX-04-02</ris:fieldOfLaw>
+          </ris:fieldsOfLaw>
+          <ris:entryIntoEffectDate>2025-01-01</ris:entryIntoEffectDate>
+          <ris:expiryDate>2025-02-02</ris:expiryDate>
+          <ris:documentType category="VR" longTitle="Bekanntmachung">VR Bekanntmachung</ris:documentType>
+          <ris:dateToQuoteList>
+            <ris:dateToQuoteEntry>2025-05-05</ris:dateToQuoteEntry>
+          </ris:dateToQuoteList>
+          <ris:referenceNumbers>
+            <ris:referenceNumber>AX-Y12345</ris:referenceNumber>
+          </ris:referenceNumbers>
+          <ris:activeReferences>
+            <ris:activeReference typeNumber="82" reference="PhanGB" paragraph="§ 1a" position="Abs 1"/>
+            <ris:activeReference typeNumber="82" reference="PhanGB" paragraph="§ 2" position="Abs 6"/>
+          </ris:activeReferences>
+        </ris:metadata>
+      </akn:proprietary>
+    </akn:meta>
+    <akn:preface>
+      <akn:longTitle>
+        <akn:block name="longTitle">1. Bekanntmachung zum XML-Testen in NeuRIS VwV</akn:block>
+      </akn:longTitle>
+    </akn:preface>
+    <akn:mainBody>
+      <akn:div>
+        <akn:p>Kurzreferat Zeile 1</akn:p>
+        <akn:p>Kurzreferat Zeile 2</akn:p>
+      </akn:div>
+    </akn:mainBody>
+  </akn:doc>
+</akn:akomaNtoso>


### PR DESCRIPTION
**Related Issue**

[RISDEV-7761](https://digitalservicebund.atlassian.net/browse/RISDEV-7761)

**Description**

- Add XML transformation of "Kurzreferat"
- Include LDML file for testing purposes
- Renamed `expirationDate` to `expiryDate` as [this name is used by migration script](https://github.com/digitalservicebund/ris-vwv-migration/blob/main/src/main/kotlin/de/bund/digitalservice/ris/vwv/migration/model/ldml/elements/meta/proprietary/RisMetadata.kt)


[RISDEV-7761]: https://digitalservicebund.atlassian.net/browse/RISDEV-7761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ