### PR TITLE
RISDEV-7632 Convert LDML to JSON on GET endpoint

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentationUnitEntity.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentationUnitEntity.java
@@ -21,4 +21,7 @@ public class DocumentationUnitEntity {
 
   @Basic
   private String json;
+
+  @Basic
+  private String xml;
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentationUnitPersistenceService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/DocumentationUnitPersistenceService.java
@@ -31,7 +31,8 @@ public class DocumentationUnitPersistenceService implements DocumentationUnitPer
         new DocumentationUnit(
           documentNumber,
           documentationUnitEntity.getId(),
-          documentationUnitEntity.getJson()
+          documentationUnitEntity.getJson(),
+          documentationUnitEntity.getXml()
         )
       );
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/DocumentationUnit.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/DocumentationUnit.java
@@ -23,4 +23,7 @@ public record DocumentationUnit(
   public DocumentationUnit(@Nonnull String documentNumber, @Nonnull UUID id, String json) {
     this(documentNumber, id, json, null);
   }
+  public DocumentationUnit(@Nonnull DocumentationUnit documentationUnit, @Nonnull String json) {
+    this(documentationUnit.documentNumber, documentationUnit.id, json, null);
+  }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/DocumentationUnitService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/DocumentationUnitService.java
@@ -1,5 +1,8 @@
 package de.bund.digitalservice.ris.adm_vwv.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.bund.digitalservice.ris.adm_vwv.application.converter.LdmlConverterService;
 import jakarta.annotation.Nonnull;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +16,34 @@ import org.springframework.stereotype.Service;
 public class DocumentationUnitService implements DocumentationUnitPort {
 
   private final DocumentationUnitPersistencePort documentationUnitPersistencePort;
+  private final LdmlConverterService ldmlConverterService;
+  private final ObjectMapper objectMapper;
 
   @Override
   public Optional<DocumentationUnit> findByDocumentNumber(@Nonnull String documentNumber) {
-    return documentationUnitPersistencePort.findByDocumentNumber(documentNumber);
+    var optionalDocumentationUnit = documentationUnitPersistencePort.findByDocumentNumber(
+      documentNumber
+    );
+    if (
+      optionalDocumentationUnit.isPresent() &&
+      optionalDocumentationUnit.map(DocumentationUnit::json).isEmpty() &&
+      optionalDocumentationUnit.map(DocumentationUnit::xml).isPresent()
+    ) {
+      // For an existing documentation unit without JSON but existing xml needs to be converted
+      DocumentationUnit documentationUnit = optionalDocumentationUnit.get();
+      var documentationUnitContent = ldmlConverterService.convertToBusinessModel(documentationUnit);
+      try {
+        return Optional.of(
+          new DocumentationUnit(
+            documentationUnit,
+            objectMapper.writeValueAsString(documentationUnitContent)
+          )
+        );
+      } catch (JsonProcessingException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+    return optionalDocumentationUnit;
   }
 
   @Override

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/DocumentationUnitServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/DocumentationUnitServiceTest.java
@@ -1,0 +1,151 @@
+package de.bund.digitalservice.ris.adm_vwv.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.BDDMockito.given;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.bund.digitalservice.ris.adm_vwv.application.converter.LdmlConverterService;
+import de.bund.digitalservice.ris.adm_vwv.application.converter.business.DocumentationUnitContent;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig
+class DocumentationUnitServiceTest {
+
+  @InjectMocks
+  private DocumentationUnitService documentationUnitService;
+
+  @Mock
+  private DocumentationUnitPersistencePort documentationUnitPersistencePort;
+
+  @Mock
+  private LdmlConverterService ldmlConverterService;
+
+  @Spy
+  private ObjectMapper objectMapper;
+
+  @Test
+  void findByDocumentNumber() {
+    // given
+    String xml =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <akn:akomaNtoso
+        xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+        xmlns:ris="http://ldml.neuris.de/metadata/">
+        <akn:doc name="offene-struktur">
+          <akn:meta>
+            <akn:proprietary>
+              <ris:metadata>
+                <ris:documentType category="VV" longTitle="Verwaltungsvorschrift">VV Verwaltungsvorschrift</ris:documentType>
+              </ris:metadata>
+            </akn:proprietary>
+          </akn:meta>
+        </akn:doc>
+      </akn:akomaNtoso>""";
+    DocumentationUnit documentationUnit = new DocumentationUnit(
+      "KSNR2025000001",
+      UUID.randomUUID(),
+      null,
+      xml
+    );
+    given(documentationUnitPersistencePort.findByDocumentNumber("KSNR2025000001")).willReturn(
+      Optional.of(documentationUnit)
+    );
+    given(ldmlConverterService.convertToBusinessModel(documentationUnit)).willReturn(
+      createDocumentationUnitContent()
+    );
+
+    // when
+    Optional<DocumentationUnit> actual = documentationUnitService.findByDocumentNumber(
+      "KSNR2025000001"
+    );
+
+    // then
+    assertThat(actual)
+      .isPresent()
+      .get()
+      .extracting(DocumentationUnit::json, InstanceOfAssertFactories.STRING)
+      .contains(
+        """
+        dokumenttyp":{"abbreviation":"VV","name":"Verwaltungsvorschrift"}"""
+      );
+  }
+
+  @Test
+  void findByDocumentNumber_notValidXml()
+    throws com.fasterxml.jackson.core.JsonProcessingException {
+    // given
+    String xml =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>""";
+    DocumentationUnit documentationUnit = new DocumentationUnit(
+      "KSNR2025000001",
+      UUID.randomUUID(),
+      null,
+      xml
+    );
+    given(documentationUnitPersistencePort.findByDocumentNumber("KSNR2025000001")).willReturn(
+      Optional.of(documentationUnit)
+    );
+    given(ldmlConverterService.convertToBusinessModel(documentationUnit)).willReturn(null);
+    given(objectMapper.writeValueAsString(null)).willThrow(JsonProcessingException.class);
+
+    // when
+    Exception exception = catchException(() ->
+      documentationUnitService.findByDocumentNumber("KSNR2025000001")
+    );
+
+    // then
+    assertThat(exception).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void findByDocumentNumber_doesNotExist() {
+    // given
+    given(documentationUnitPersistencePort.findByDocumentNumber("KSNR112233445566")).willReturn(
+      Optional.empty()
+    );
+
+    // when
+    Optional<DocumentationUnit> actual = documentationUnitService.findByDocumentNumber(
+      "KSNR112233445566"
+    );
+
+    // then
+    assertThat(actual).isEmpty();
+  }
+
+  private static DocumentationUnitContent createDocumentationUnitContent() {
+    return new DocumentationUnitContent(
+      UUID.randomUUID(),
+      "KSNR2025000001",
+      List.of(),
+      List.of(),
+      null,
+      List.of(),
+      null,
+      null,
+      null,
+      List.of(),
+      null,
+      List.of(),
+      false,
+      new DocumentType("VV", "Verwaltungsvorschrift"),
+      "Verwaltungsvorschrift",
+      List.of(),
+      List.of(),
+      List.of(),
+      null
+    );
+  }
+}


### PR DESCRIPTION
**Related Issue**

[RISDEV-7632](https://digitalservicebund.atlassian.net/browse/RISDEV-7632)

**Description**

On GET endpoint of documentation unit convert LDML/XML to JSON in case there is XML but no JSON persisted.


[RISDEV-7632]: https://digitalservicebund.atlassian.net/browse/RISDEV-7632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ