### PR TITLE
RISDEV-7821 Fix 'Kurzreferat' transformer

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/ldml/MainBody.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/ldml/MainBody.java
@@ -14,4 +14,7 @@ public class MainBody {
 
   @XmlElement(namespace = XmlNamespace.AKN_NS)
   private JaxbHtml div;
+
+  @XmlElement(namespace = XmlNamespace.AKN_NS)
+  private JaxbHtml hcontainer;
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformer.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformer.java
@@ -2,7 +2,6 @@ package de.bund.digitalservice.ris.adm_vwv.application.converter.transform;
 
 import de.bund.digitalservice.ris.adm_vwv.application.converter.XmlWriter;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.AkomaNtoso;
-import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.JaxbHtml;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.MainBody;
 import lombok.RequiredArgsConstructor;
 
@@ -22,12 +21,13 @@ public class KurzreferatTransformer {
    */
   public String transform() {
     MainBody mainBody = akomaNtoso.getDoc().getMainBody();
-    if (mainBody == null) {
+    if (mainBody == null || mainBody.getHcontainer() != null) {
+      // There are documents without a Kurzreferat. For pleasing LDML those documents do not contain a <div> tag,
+      // but a <hcontainer> tag.
       return null;
     }
-    JaxbHtml div = mainBody.getDiv();
     return xmlWriter
-      .writeXml(div, false)
+      .writeXml(mainBody.getDiv(), false)
       // Replace wrapper element completely
       .replaceAll("</?jaxbHtml.*>", "")
       // Remove akn prefix from tag names, e.g. <akn:p> is transformed to <p>

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterServiceTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 class LdmlConverterServiceTest {
@@ -109,6 +110,27 @@ class LdmlConverterServiceTest {
     assertThat(documentationUnitContent.kurzreferat())
       .isNotNull()
       .containsSubsequence("<p>Kurzreferat Zeile 1</p>", "<p>Kurzreferat Zeile 2</p>");
+  }
+
+  @Test
+  @Tag("RISDEV-7821")
+  void convertToBusinessModel_noKurzreferat() {
+    // given
+    String xml = TestFile.readFileToString("ldml-no-kurzreferat.akn.xml");
+    DocumentationUnit documentationUnit = new DocumentationUnit(
+      "KSNR20250000001",
+      UUID.randomUUID(),
+      null,
+      xml
+    );
+
+    // when
+    DocumentationUnitContent documentationUnitContent = ldmlConverterService.convertToBusinessModel(
+      documentationUnit
+    );
+
+    // then
+    assertThat(documentationUnitContent.kurzreferat()).isNull();
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformerTest.java
@@ -6,6 +6,7 @@ import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.*;
 import jakarta.xml.bind.JAXBElement;
 import java.util.List;
 import javax.xml.namespace.QName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 class KurzreferatTransformerTest {
@@ -40,6 +41,28 @@ class KurzreferatTransformerTest {
     akomaNtoso.setDoc(doc);
     Meta meta = new Meta();
     doc.setMeta(meta);
+
+    // when
+    String actualKurzreferat = new KurzreferatTransformer(akomaNtoso).transform();
+
+    // then
+    assertThat(actualKurzreferat).isNull();
+  }
+
+  @Test
+  @Tag("RISDEV-7821")
+  void transform_mainBodyElementWithHContainer() {
+    // given
+    AkomaNtoso akomaNtoso = new AkomaNtoso();
+    Doc doc = new Doc();
+    akomaNtoso.setDoc(doc);
+    Meta meta = new Meta();
+    doc.setMeta(meta);
+    MainBody mainBody = new MainBody();
+    JaxbHtml hcontainer = new JaxbHtml();
+    hcontainer.setName("crossheading");
+    mainBody.setHcontainer(hcontainer);
+    doc.setMainBody(mainBody);
 
     // when
     String actualKurzreferat = new KurzreferatTransformer(akomaNtoso).transform();

--- a/backend/src/test/resources/ldml-no-kurzreferat.akn.xml
+++ b/backend/src/test/resources/ldml-no-kurzreferat.akn.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akn:akomaNtoso xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+  xmlns:ris="http://ldml.neuris.de/metadata/">
+  <akn:doc name="offene-struktur">
+    <akn:meta>
+      <akn:identification source="attributsemantik-noch-undefiniert">
+        <!-- omitted -->
+      </akn:identification>
+      <akn:classification source="attributsemantik-noch-undefiniert">
+        <akn:keyword showAs="Schlag" dictionary="attributsemantik-noch-undefiniert" value="Schlag"/>
+        <akn:keyword showAs="Wort" dictionary="attributsemantik-noch-undefiniert" value="Wort"/>
+        <akn:keyword showAs="Mehrere Wörter in einem Schlagwort" dictionary="attributsemantik-noch-undefiniert" value="Mehrere Wörter in einem Schlagwort"/>
+      </akn:classification>
+      <akn:analysis source="attributsemantik-noch-undefiniert">
+        <akn:otherReferences source="attributsemantik-noch-undefiniert">
+          <akn:implicitReference shortForm="Das Periodikum" showAs="Das Periodikum 2021, Seite 15"/>
+        </akn:otherReferences>
+        <akn:otherReferences source="attributsemantik-noch-undefiniert">
+          <akn:implicitReference shortForm="PhanGB" showAs="PhanGB § 1a Abs 1">
+            <ris:normReference singleNorm="§ 1a Abs 1" dateOfRelevance="2011" dateOfVersion="2022-02-02"/>
+          </akn:implicitReference>
+        </akn:otherReferences>
+        <akn:otherReferences source="attributsemantik-noch-undefiniert">
+          <akn:implicitReference shortForm="PhanGB 5" showAs="PhanGB 5 § 2 Abs 6">
+            <ris:normReference singleNorm="§ 2 Abs 6" dateOfRelevance="2011" dateOfVersion="2022-02-02"/>
+          </akn:implicitReference>
+        </akn:otherReferences>
+        <akn:otherReferences source="attributsemantik-noch-undefiniert">
+          <akn:implicitReference shortForm="Vgl PhanGH C-01/02" showAs="Vgl PhanGH C-01/02 2021-10-20">
+            <ris:caselawReference abbreviation="Vgl" court="PhanGH" date="2021-10-20" referenceNumber="C-01/02"
+                                  documentNumber="WBRE000001234"/>
+          </akn:implicitReference>
+        </akn:otherReferences>
+      </akn:analysis>
+      <akn:proprietary source="attributsemantik-noch-undefiniert">
+        <ris:metadata>
+          <ris:normgeber staat="DS"/>
+          <ris:fieldsOfLaw>
+            <ris:fieldOfLaw notation="neu">PR-05-01</ris:fieldOfLaw>
+            <ris:fieldOfLaw notation="neu">XX-04-02</ris:fieldOfLaw>
+          </ris:fieldsOfLaw>
+          <ris:entryIntoEffectDate>2025-01-01</ris:entryIntoEffectDate>
+          <ris:expiryDate>2025-02-02</ris:expiryDate>
+          <ris:tableOfContentsEntries>
+            <ris:tableOfContentsEntry>TOC entry 1</ris:tableOfContentsEntry>
+            <ris:tableOfContentsEntry>TOC entry 2</ris:tableOfContentsEntry>
+          </ris:tableOfContentsEntries>
+          <ris:documentType category="VR" longTitle="Bekanntmachung">VR Bekanntmachung</ris:documentType>
+          <ris:dateToQuoteList>
+            <ris:dateToQuoteEntry>2025-05-05</ris:dateToQuoteEntry>
+          </ris:dateToQuoteList>
+          <ris:referenceNumbers>
+            <ris:referenceNumber>AX-Y12345</ris:referenceNumber>
+            <ris:referenceNumber>XX</ris:referenceNumber>
+          </ris:referenceNumbers>
+          <ris:activeReferences>
+            <ris:activeReference typeNumber="82" reference="PhanGB" paragraph="§ 1a" position="Abs 1"/>
+            <ris:activeReference typeNumber="82" reference="PhanGB" paragraph="§ 2" position="Abs 6"/>
+          </ris:activeReferences>
+        </ris:metadata>
+      </akn:proprietary>
+    </akn:meta>
+    <akn:preface>
+      <akn:longTitle>
+        <akn:block name="longTitle">1. Bekanntmachung zum XML-Testen in NeuRIS VwV</akn:block>
+      </akn:longTitle>
+    </akn:preface>
+    <akn:mainBody>
+      <akn:hcontainer name="crossheading"/>
+    </akn:mainBody>
+  </akn:doc>
+</akn:akomaNtoso>


### PR DESCRIPTION
**Related Issue**

[RISDEV-7821](https://digitalservicebund.atlassian.net/browse/RISDEV-7821)

**Description**

Do not fail on empty mainBody with hcontainer for transforming 'Kurzreferat'.
