### PR TITLE
RISDEV-7936 Fix NonUniqueResultException in NormgeberTransformer

### DIFF
--- a/backend/docker-initialization/create_tables.sql
+++ b/backend/docker-initialization/create_tables.sql
@@ -280,7 +280,9 @@ INSERT INTO institution (id, name, official_name, foreign_country, juris_id, typ
            (gen_random_uuid(), 'Zweites Organ', NULL, NULL, '2', 'organ'),
            ('bddafc08-4031-4960-9aad-0868d48323f7', 'Erste Jurpn', 'Jurpn Eins', 'Nein', '1', 'jurpn'),
            (gen_random_uuid(), 'Zweite Jurpn', NULL, 'Ja', '2', 'jurpn'),
-           ('32b0a3fd-e340-4f9b-bd39-7fe2dcff9a75', 'Dritte Jurpn', NULL, 'Nein', '3', 'jurpn');
+           ('32b0a3fd-e340-4f9b-bd39-7fe2dcff9a75', 'Dritte Jurpn', NULL, 'Nein', '3', 'jurpn'),
+           (gen_random_uuid(), 'JurpnOrgan', NULL, 'Nein', '4', 'jurpn'),
+           (gen_random_uuid(), 'JurpnOrgan', NULL, 'Nein', '5', 'organ');
 INSERT INTO institution_region (institution_id, region_id) VALUES
         ('bddafc08-4031-4960-9aad-0868d48323f7', '14af4110-fa58-4753-a949-6b6ba2dbcfe1'),
         ('bddafc08-4031-4960-9aad-0868d48323f7', '01c63c40-74b4-486a-8914-083e7f03baef'),

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/InstitutionRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/InstitutionRepository.java
@@ -12,5 +12,5 @@ interface InstitutionRepository extends JpaRepository<InstitutionEntity, UUID> {
     @Nonnull String name,
     @Nonnull Pageable pageable
   );
-  Optional<InstitutionEntity> findByName(@Nonnull String name);
+  Optional<InstitutionEntity> findByNameAndType(@Nonnull String name, @Nonnull String type);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/InstitutionTypeMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/InstitutionTypeMapper.java
@@ -1,0 +1,27 @@
+package de.bund.digitalservice.ris.adm_vwv.adapter.persistence;
+
+import de.bund.digitalservice.ris.adm_vwv.application.InstitutionType;
+import jakarta.annotation.Nonnull;
+import java.util.Map;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.collections4.BidiMap;
+import org.apache.commons.collections4.bidimap.DualHashBidiMap;
+
+/**
+ * Utility class for mapping instances of {@link de.bund.digitalservice.ris.adm_vwv.application.InstitutionType} to {@code String} and vice versa.
+ */
+@UtilityClass
+class InstitutionTypeMapper {
+
+  private static final BidiMap<String, InstitutionType> MAPPING = new DualHashBidiMap<>(
+    Map.of("organ", InstitutionType.INSTITUTION, "jurpn", InstitutionType.LEGAL_ENTITY)
+  );
+
+  String mapInstitutionType(@Nonnull InstitutionType institutionType) {
+    return MAPPING.inverseBidiMap().get(institutionType);
+  }
+
+  InstitutionType mapInstitutionTypeString(@Nonnull String type) {
+    return MAPPING.get(type);
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/LookupTablesPersistenceService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/LookupTablesPersistenceService.java
@@ -1,5 +1,7 @@
 package de.bund.digitalservice.ris.adm_vwv.adapter.persistence;
 
+import static de.bund.digitalservice.ris.adm_vwv.adapter.persistence.InstitutionTypeMapper.*;
+
 import de.bund.digitalservice.ris.adm_vwv.application.*;
 import de.bund.digitalservice.ris.adm_vwv.application.Page;
 import jakarta.annotation.Nonnull;
@@ -218,8 +220,13 @@ public class LookupTablesPersistenceService implements LookupTablesPersistencePo
 
   @Override
   @Transactional(readOnly = true)
-  public Optional<Institution> findInstitutionByName(@Nonnull String name) {
-    return institutionRepository.findByName(name).map(mapInstitutionEntity());
+  public Optional<Institution> findInstitutionByNameAndType(
+    @Nonnull String name,
+    @Nonnull InstitutionType institutionType
+  ) {
+    return institutionRepository
+      .findByNameAndType(name, mapInstitutionType(institutionType))
+      .map(mapInstitutionEntity());
   }
 
   private Function<InstitutionEntity, Institution> mapInstitutionEntity() {
@@ -228,17 +235,9 @@ public class LookupTablesPersistenceService implements LookupTablesPersistencePo
         institutionEntity.getId(),
         institutionEntity.getName(),
         institutionEntity.getOfficialName(),
-        mapInstitutionType(institutionEntity.getType()),
+        mapInstitutionTypeString(institutionEntity.getType()),
         institutionEntity.getRegions().stream().map(mapRegionEntity()).toList()
       );
-  }
-
-  private InstitutionType mapInstitutionType(String institutionType) {
-    return switch (institutionType) {
-      case "jurpn" -> InstitutionType.LEGAL_ENTITY;
-      case "organ" -> InstitutionType.INSTITUTION;
-      default -> null;
-    };
   }
 
   private List<String> splitSearchTerms(String searchStr) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesPersistencePort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/LookupTablesPersistencePort.java
@@ -25,5 +25,8 @@ public interface LookupTablesPersistencePort {
   Optional<Region> findRegionByCode(@Nonnull String code);
 
   Page<Institution> findInstitutions(@Nonnull InstitutionQuery query);
-  Optional<Institution> findInstitutionByName(@Nonnull String name);
+  Optional<Institution> findInstitutionByNameAndType(
+    @Nonnull String name,
+    @Nonnull InstitutionType type
+  );
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/NormgeberTransformer.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/NormgeberTransformer.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.adm_vwv.application.converter.transform;
 
 import de.bund.digitalservice.ris.adm_vwv.application.Institution;
+import de.bund.digitalservice.ris.adm_vwv.application.InstitutionType;
 import de.bund.digitalservice.ris.adm_vwv.application.LookupTablesPersistencePort;
 import de.bund.digitalservice.ris.adm_vwv.application.Region;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.business.Normgeber;
@@ -41,14 +42,16 @@ public class NormgeberTransformer {
     return risNormgeberList
       .stream()
       .map(risNormgeber -> {
-        String institutionName = risNormgeber.getOrgan() != null
-          ? risNormgeber.getOrgan()
-          : risNormgeber.getStaat();
+        InstitutionType institutionType = InstitutionType.LEGAL_ENTITY;
+        String institutionName = risNormgeber.getStaat();
+        if (risNormgeber.getOrgan() != null) {
+          institutionType = InstitutionType.INSTITUTION;
+          institutionName = risNormgeber.getOrgan();
+        }
+        String summary = institutionName + " (" + institutionType + ")";
         Institution institution = lookupTablesPersistencePort
-          .findInstitutionByName(institutionName)
-          .orElseThrow(() ->
-            new IllegalArgumentException("Institution not found: " + institutionName)
-          );
+          .findInstitutionByNameAndType(institutionName, institutionType)
+          .orElseThrow(() -> new IllegalArgumentException("Institution not found: " + summary));
         List<Region> regions = new ArrayList<>();
         if (risNormgeber.getOrgan() != null) {
           regions.add(

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/InstitutionTypeMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/adapter/persistence/InstitutionTypeMapperTest.java
@@ -1,0 +1,50 @@
+package de.bund.digitalservice.ris.adm_vwv.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.bund.digitalservice.ris.adm_vwv.application.InstitutionType;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class InstitutionTypeMapperTest {
+
+  private static Stream<Arguments> institutionTypes() {
+    return Stream.of(
+      Arguments.of(InstitutionType.LEGAL_ENTITY, "jurpn"),
+      Arguments.of(InstitutionType.INSTITUTION, "organ")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("institutionTypes")
+  void mapInstitutionType(InstitutionType institutionType, String expected) {
+    // given
+
+    // when
+    String type = InstitutionTypeMapper.mapInstitutionType(institutionType);
+
+    // then
+    assertThat(type).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> institutionTypesFromString() {
+    return Stream.of(
+      Arguments.of("jurpn", InstitutionType.LEGAL_ENTITY),
+      Arguments.of("organ", InstitutionType.INSTITUTION)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("institutionTypesFromString")
+  void mapInstitutionTypeString(String type, InstitutionType expected) {
+    // given
+
+    // when
+    InstitutionType institutionType = InstitutionTypeMapper.mapInstitutionTypeString(type);
+
+    // then
+    assertThat(institutionType).isEqualTo(expected);
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterServiceIntegrationTest.java
@@ -610,4 +610,40 @@ class LdmlConverterServiceIntegrationTest {
         tuple("Erstes Organ", InstitutionType.INSTITUTION, List.of("AA"))
       );
   }
+
+  @Test
+  @Tag("RISDEV-7936")
+  void convertToBusinessModel_normgeberEqualNameForLegalEntityAndOrgan() {
+    // given
+    String xml = TestFile.readFileToString("ldml-example-normgeber.akn.xml");
+    DocumentationUnit documentationUnit = new DocumentationUnit(
+      "KSNR20250000001",
+      UUID.randomUUID(),
+      null,
+      xml
+    );
+
+    // when
+    DocumentationUnitContent documentationUnitContent = ldmlConverterService.convertToBusinessModel(
+      documentationUnit
+    );
+
+    // then
+    assertThat(documentationUnitContent)
+      .isNotNull()
+      .extracting(
+        DocumentationUnitContent::normgeberList,
+        InstanceOfAssertFactories.list(Normgeber.class)
+      )
+      .hasSize(2)
+      .extracting(
+        normgeber -> normgeber.institution().name(),
+        normgeber -> normgeber.institution().type(),
+        normgeber -> normgeber.regions().stream().map(Region::code).toList()
+      )
+      .containsExactly(
+        tuple("JurpnOrgan", InstitutionType.LEGAL_ENTITY, List.of()),
+        tuple("JurpnOrgan", InstitutionType.INSTITUTION, List.of("AA"))
+      );
+  }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/NormgeberTransformerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/NormgeberTransformerTest.java
@@ -31,7 +31,6 @@ class NormgeberTransformerTest {
   @DisplayName("Transforms two normgeber, one legal entity and one institution with region")
   void transform() {
     // given
-
     AkomaNtoso akomaNtoso = new AkomaNtoso();
     Doc doc = new Doc();
     akomaNtoso.setDoc(doc);
@@ -47,11 +46,14 @@ class NormgeberTransformerTest {
         createRisNormgeber("BRD", "Ministerium für Digitales")
       )
     );
-    given(lookupTablesPersistencePort.findInstitutionByName("DS")).willReturn(
-      createInstitution("DS", InstitutionType.LEGAL_ENTITY)
-    );
     given(
-      lookupTablesPersistencePort.findInstitutionByName("Ministerium für Digitales")
+      lookupTablesPersistencePort.findInstitutionByNameAndType("DS", InstitutionType.LEGAL_ENTITY)
+    ).willReturn(createInstitution("DS", InstitutionType.LEGAL_ENTITY));
+    given(
+      lookupTablesPersistencePort.findInstitutionByNameAndType(
+        "Ministerium für Digitales",
+        InstitutionType.INSTITUTION
+      )
     ).willReturn(createInstitution("Ministerium für Digitales", InstitutionType.INSTITUTION));
     given(lookupTablesPersistencePort.findRegionByCode("BRD")).willReturn(createRegion());
 

--- a/backend/src/test/resources/ldml-example-normgeber.akn.xml
+++ b/backend/src/test/resources/ldml-example-normgeber.akn.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akn:akomaNtoso xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+  xmlns:ris="http://ldml.neuris.de/metadata/">
+  <akn:doc name="offene-struktur">
+    <akn:meta>
+      <akn:identification source="attributsemantik-noch-undefiniert">
+        <!-- omitted -->
+      </akn:identification>
+      <akn:classification source="attributsemantik-noch-undefiniert">
+        <akn:keyword showAs="Schlag" dictionary="attributsemantik-noch-undefiniert" value="Schlag"/>
+        <akn:keyword showAs="Wort" dictionary="attributsemantik-noch-undefiniert" value="Wort"/>
+        <akn:keyword showAs="Mehrere Wörter in einem Schlagwort" dictionary="attributsemantik-noch-undefiniert" value="Mehrere Wörter in einem Schlagwort"/>
+      </akn:classification>
+      <akn:analysis source="attributsemantik-noch-undefiniert">
+        <akn:otherReferences source="attributsemantik-noch-undefiniert">
+          <akn:implicitReference shortForm="Das Periodikum" showAs="Das Periodikum 2021, Seite 15"/>
+        </akn:otherReferences>
+        <akn:otherReferences source="attributsemantik-noch-undefiniert">
+          <akn:implicitReference shortForm="PhanGB" showAs="PhanGB § 1a Abs 1">
+            <ris:normReference singleNorm="§ 1a Abs 1" dateOfRelevance="2011" dateOfVersion="2022-02-02"/>
+          </akn:implicitReference>
+        </akn:otherReferences>
+        <akn:otherReferences source="attributsemantik-noch-undefiniert">
+          <akn:implicitReference shortForm="PhanGB 5" showAs="PhanGB 5 § 2 Abs 6">
+            <ris:normReference singleNorm="§ 2 Abs 6" dateOfRelevance="2011" dateOfVersion="2022-02-02"/>
+          </akn:implicitReference>
+        </akn:otherReferences>
+        <akn:otherReferences source="attributsemantik-noch-undefiniert">
+          <akn:implicitReference shortForm="Vgl PhanGH C-01/02" showAs="Vgl PhanGH C-01/02 2021-10-20">
+            <ris:caselawReference abbreviation="Vgl" court="PhanGH" date="2021-10-20" referenceNumber="C-01/02"
+                                  documentNumber="WBRE000001234"/>
+          </akn:implicitReference>
+        </akn:otherReferences>
+      </akn:analysis>
+      <akn:proprietary source="attributsemantik-noch-undefiniert">
+        <ris:metadata>
+          <ris:normgeber staat="JurpnOrgan"/>
+          <ris:normgeber staat="AA" organ="JurpnOrgan"/>
+          <ris:fieldsOfLaw>
+            <ris:fieldOfLaw notation="neu">PR-05-01</ris:fieldOfLaw>
+            <ris:fieldOfLaw notation="neu">XX-04-02</ris:fieldOfLaw>
+          </ris:fieldsOfLaw>
+          <ris:entryIntoEffectDate>2025-01-01</ris:entryIntoEffectDate>
+          <ris:expiryDate>2025-02-02</ris:expiryDate>
+          <ris:tableOfContentsEntries>
+            <ris:tableOfContentsEntry>TOC entry 1</ris:tableOfContentsEntry>
+            <ris:tableOfContentsEntry>TOC entry 2</ris:tableOfContentsEntry>
+          </ris:tableOfContentsEntries>
+          <ris:documentType category="VR" longTitle="Bekanntmachung">VR Bekanntmachung</ris:documentType>
+          <ris:dateToQuoteList>
+            <ris:dateToQuoteEntry>2025-05-05</ris:dateToQuoteEntry>
+          </ris:dateToQuoteList>
+          <ris:referenceNumbers>
+            <ris:referenceNumber>AX-Y12345</ris:referenceNumber>
+            <ris:referenceNumber>XX</ris:referenceNumber>
+          </ris:referenceNumbers>
+          <ris:activeReferences>
+            <ris:activeReference typeNumber="82" reference="PhanGB" paragraph="§ 1a" position="Abs 1"/>
+            <ris:activeReference typeNumber="82" reference="PhanGB" paragraph="§ 2" position="Abs 6"/>
+          </ris:activeReferences>
+        </ris:metadata>
+      </akn:proprietary>
+    </akn:meta>
+    <akn:preface>
+      <akn:longTitle>
+        <akn:block name="longTitle">1. Bekanntmachung zum XML-Testen in NeuRIS VwV</akn:block>
+      </akn:longTitle>
+    </akn:preface>
+    <akn:mainBody>
+      <akn:div>
+        <akn:p>Kurzreferat Zeile 1</akn:p>
+        <akn:p>Kurzreferat Zeile 2</akn:p>
+      </akn:div>
+    </akn:mainBody>
+  </akn:doc>
+</akn:akomaNtoso>


### PR DESCRIPTION
**Related Issue**

[RISDEV-7936](https://digitalservicebund.atlassian.net/browse/RISDEV-7936)

**Description**

Fixing possible NonUniqueResultException on `NormgeberTransformer` if the same name is used for a legal entity and an institution.


[RISDEV-7936]: https://digitalservicebund.atlassian.net/browse/RISDEV-7936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ