### PR TITLE
Handle CVE-2025-4575

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     // CVE-2023-51775
     exclude("org.bitbucket.b_c", "jose4j")
   }
-
+// libcrypto is not part of our spring setup, must be in the file system
   implementation("com.google.protobuf:protobuf-java:4.31.1")
   implementation("org.bitbucket.b_c:jose4j:0.9.6")
   implementation("org.springframework.retry:spring-retry")


### PR DESCRIPTION
* Github security report: https://github.com/digitalservicebund/ris-adm-vwv/security/code-scanning/23
* There's no libcrypto in our backend code.
  *  There is `spring-security-crypto`, but our v.6.5.0 is not affected ([source](https://mvnrepository.com/artifact/org.springframework.security/spring-security-crypto))

* Hypothesis: it's a linux dependency. 
  * Check which run of trivy reported `libcrypto`. 
  * Our hypothesis is that it's the trivy on the backend image
    * Indeed, it shows [here](https://github.com/digitalservicebund/ris-adm-vwv/actions/runs/15386856122/job/43287179224#step:8:44)
    * It does not show in the filesystem check ([source](https://github.com/digitalservicebund/ris-adm-vwv/actions/runs/15386856122/job/43287179229))
    * it does not show in the frontend image ([source](https://github.com/digitalservicebund/ris-adm-vwv/actions/runs/15386856122/job/43287179248))

* This can be confirmed as a Ubuntu 24.04 related security problem  ([source](https://ubuntu.com/security/CVE-2025-4575)), however, while 
  * there are several packages related to the CVE, 
  * all are reported as "not affected" in the 24.04 by Canonical, 
  * ranking it "low" in general

* We do not have to take action.
