### PR TITLE
RISDEV-8141 Wrap jaxb context into a singleton

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
   implementation("org.flywaydb:flyway-core")
   implementation("org.flywaydb:flyway-database-postgresql")
   implementation("org.springframework.session:spring-session-core")
+  implementation("jakarta.xml.bind:jakarta.xml.bind-api")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
   implementation("io.sentry:sentry-spring-boot-starter-jakarta:$sentryVersion")
   implementation("io.sentry:sentry-logback:$sentryVersion")

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlConverterService.java
@@ -18,11 +18,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class LdmlConverterService {
 
-  private final XmlReader xmlReader = new XmlReader();
+  private final XmlReader xmlReader;
   private final FundstellenTransformer fundstellenTransformer;
   private final DocumentTypeTransformer documentTypeTransformer;
   private final NormgeberTransformer normgeberTransformer;
   private final FieldsOfLawTransformer fieldsOfLawTransformer;
+  private final KurzreferatTransformer kurzreferatTransformer;
 
   /**
    * Converts the xml of the given documentation unit to business models.
@@ -47,7 +48,7 @@ public class LdmlConverterService {
       new EntryIntoEffectDateTransformer(akomaNtoso).transform(),
       new ExpiryDateTransformer(akomaNtoso).transform(),
       new TableOfContentsTransformer().transform(akomaNtoso),
-      new KurzreferatTransformer(akomaNtoso).transform(),
+      kurzreferatTransformer.transform(akomaNtoso),
       referenceNumbers,
       referenceNumbers.isEmpty(),
       documentTypeTransformer.transform(akomaNtoso),

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlReader.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlReader.java
@@ -6,13 +6,19 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 import java.io.StringReader;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 /**
  * Xml reader.
  */
 @Slf4j
+@Component
+@RequiredArgsConstructor
 public class XmlReader {
+
+  private final JAXBContext jaxbContext;
 
   /**
    * Transforms a plain string of XML into Java.
@@ -21,7 +27,6 @@ public class XmlReader {
    */
   public AkomaNtoso readXml(@Nonnull String xml) {
     try {
-      JAXBContext jaxbContext = JAXBContext.newInstance(AkomaNtoso.class);
       Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
       return (AkomaNtoso) unmarshaller.unmarshal(new StringReader(xml));
     } catch (JAXBException e) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlWriter.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlWriter.java
@@ -1,19 +1,23 @@
 package de.bund.digitalservice.ris.adm_vwv.application.converter;
 
-import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.AkomaNtoso;
-import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.JaxbHtml;
 import jakarta.annotation.Nonnull;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import java.io.StringWriter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 /**
  * Xml writer.
  */
 @Slf4j
+@Component
+@RequiredArgsConstructor
 public class XmlWriter {
+
+  private final JAXBContext jaxbContext;
 
   /**
    * Transforms a JAXb element into a string. The output contains an XML header node.
@@ -33,8 +37,6 @@ public class XmlWriter {
    */
   public String writeXml(@Nonnull Object jaxbElement, boolean includeHeader) {
     try {
-      // Create JAXB instance with all possible root elements
-      JAXBContext jaxbContext = JAXBContext.newInstance(AkomaNtoso.class, JaxbHtml.class);
       Marshaller marshaller = jaxbContext.createMarshaller();
       marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
       marshaller.setProperty(Marshaller.JAXB_FRAGMENT, !includeHeader);

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformer.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformer.java
@@ -6,22 +6,24 @@ import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.JaxbHtml;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.MainBody;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 /**
  * Kurzreferat transformer.
  */
+@Component
 @RequiredArgsConstructor
 public class KurzreferatTransformer {
 
-  private final AkomaNtoso akomaNtoso;
-  private final XmlWriter xmlWriter = new XmlWriter();
+  private final XmlWriter xmlWriter;
 
   /**
    * Transforms the {@code AkomaNtoso} object to a 'Kurzreferat' HTML string.
    *
+   * @param akomaNtoso The Akoma Ntoso XML object to transform
    * @return The 'Kurzreferat' HTML, or {@code null} if the surrounding {@code <mainBody>} element is {@code null}.
    */
-  public String transform() {
+  public String transform(AkomaNtoso akomaNtoso) {
     MainBody mainBody = akomaNtoso.getDoc().getMainBody();
     if (mainBody == null || mainBody.getHcontainer() != null) {
       // There are documents without a Kurzreferat. For pleasing LDML those documents do not contain a <div> tag,

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/config/JaxbConfiguration.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/config/JaxbConfiguration.java
@@ -4,6 +4,7 @@ import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.AkomaNtoso;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.JaxbHtml;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
  * Jaxb configuration to hold a singleton jaxb context bean.
  */
 @Configuration
+@Slf4j
 public class JaxbConfiguration {
 
   /**
@@ -21,6 +23,8 @@ public class JaxbConfiguration {
   @Bean
   public JAXBContext jaxbContext() throws JAXBException {
     // Create JAXB instance with all possible root elements
-    return JAXBContext.newInstance(AkomaNtoso.class, JaxbHtml.class);
+    JAXBContext jaxbContext = JAXBContext.newInstance(AkomaNtoso.class, JaxbHtml.class);
+    log.info("JAXB context created.");
+    return jaxbContext;
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/config/JaxbConfiguration.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/adm_vwv/config/JaxbConfiguration.java
@@ -1,0 +1,26 @@
+package de.bund.digitalservice.ris.adm_vwv.config;
+
+import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.AkomaNtoso;
+import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.JaxbHtml;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Jaxb configuration to hold a singleton jaxb context bean.
+ */
+@Configuration
+public class JaxbConfiguration {
+
+  /**
+   * Creates a jaxb context bean.
+   * @return Returns a jaxb context bean
+   * @throws JAXBException In case the context could not be created
+   */
+  @Bean
+  public JAXBContext jaxbContext() throws JAXBException {
+    // Create JAXB instance with all possible root elements
+    return JAXBContext.newInstance(AkomaNtoso.class, JaxbHtml.class);
+  }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -20,7 +20,7 @@ springdoc:
 
 # Every day from Monday to Friday at 5 am
 #cronjob.DocumentationUnitIndexJob: "0 0 8 * * Mon-Fri"
-cronjob.DocumentationUnitIndexJob: "-"
+cronjob.DocumentationUnitIndexJob: "0 0/15 * * * Mon-Fri"
 
 ---
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlReaderTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlReaderTest.java
@@ -3,12 +3,23 @@ package de.bund.digitalservice.ris.adm_vwv.application.converter;
 import static org.assertj.core.api.Assertions.*;
 
 import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.AkomaNtoso;
+import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.JaxbHtml;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+@SpringJUnitConfig
 class XmlReaderTest {
 
-  private final XmlReader xmlReader = new XmlReader();
+  private XmlReader xmlReader;
+
+  @BeforeEach
+  void beforeEach() throws JAXBException {
+    xmlReader = new XmlReader(JAXBContext.newInstance(AkomaNtoso.class, JaxbHtml.class));
+  }
 
   @Test
   void readXml() {

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlWriterTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/XmlWriterTest.java
@@ -4,12 +4,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
 import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.*;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+@SpringJUnitConfig
 class XmlWriterTest {
 
-  private final XmlWriter xmlWriter = new XmlWriter();
+  private XmlWriter xmlWriter;
+
+  @BeforeEach
+  void beforeEach() throws JAXBException {
+    xmlWriter = new XmlWriter(JAXBContext.newInstance(AkomaNtoso.class, JaxbHtml.class));
+  }
 
   @Test
   void writeXml() {

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/transform/KurzreferatTransformerTest.java
@@ -2,14 +2,29 @@ package de.bund.digitalservice.ris.adm_vwv.application.converter.transform;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.bund.digitalservice.ris.adm_vwv.application.converter.XmlWriter;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.ldml.*;
+import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
 import java.util.List;
 import javax.xml.namespace.QName;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+@SpringJUnitConfig
 class KurzreferatTransformerTest {
+
+  private KurzreferatTransformer kurzreferatTransformer;
+
+  @BeforeEach
+  void beforeEach() throws JAXBException {
+    kurzreferatTransformer = new KurzreferatTransformer(
+      new XmlWriter(JAXBContext.newInstance(AkomaNtoso.class, JaxbHtml.class))
+    );
+  }
 
   @Test
   void transform() {
@@ -27,7 +42,7 @@ class KurzreferatTransformerTest {
     div.setHtml(List.of(textNode, line1, textNode, line2, textNode));
 
     // when
-    String actualKurzreferat = new KurzreferatTransformer(akomaNtoso).transform();
+    String actualKurzreferat = kurzreferatTransformer.transform(akomaNtoso);
 
     // then
     assertThat(actualKurzreferat).startsWith("<p>Zeile 1</p>").endsWith("<p>Zeile 2</p>");
@@ -43,7 +58,7 @@ class KurzreferatTransformerTest {
     doc.setMeta(meta);
 
     // when
-    String actualKurzreferat = new KurzreferatTransformer(akomaNtoso).transform();
+    String actualKurzreferat = kurzreferatTransformer.transform(akomaNtoso);
 
     // then
     assertThat(actualKurzreferat).isNull();
@@ -65,7 +80,7 @@ class KurzreferatTransformerTest {
     doc.setMainBody(mainBody);
 
     // when
-    String actualKurzreferat = new KurzreferatTransformer(akomaNtoso).transform();
+    String actualKurzreferat = kurzreferatTransformer.transform(akomaNtoso);
 
     // then
     assertThat(actualKurzreferat).isNull();


### PR DESCRIPTION
**Related Issue**

[RISDEV-8141](https://digitalservicebund.atlassian.net/browse/RISDEV-8141)

**Description**

Do not create JaxbContext every time it is needed; instead create it on startup and re-use it.


[RISDEV-8141]: https://digitalservicebund.atlassian.net/browse/RISDEV-8141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ