### PR TITLE
Wait for backend test result before running sonar.

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -115,12 +115,19 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   check-code-quality-with-sonarqube-backend:
+    needs: [test-backend]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Download backend test report from job 'test-backend'
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-test-report
+          path: tmp/backend-test-report
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -114,7 +114,7 @@ tasks.jacocoTestReport {
 }
 
 tasks.getByName("sonar") {
-  dependsOn("jacocoTestReport")
+  // dependsOn("jacocoTestReport")
 }
 
 sonar {


### PR DESCRIPTION
Download test result before running sonar.

**Related Issue**

https://digitalservicebund.atlassian.net/jira/software/c/projects/RISDEV/boards/224?selectedIssue=RISDEV-8170

**Description**

Find out the runtime performance effects of running sonar on the test report that the `test-backend` job created instead of sonar running the tests (again).
