### PR TITLE
Non-blocking trivy on `main`

### DIFF
--- a/.github/workflows/backend-build-image-and-scan.yml
+++ b/.github/workflows/backend-build-image-and-scan.yml
@@ -60,8 +60,9 @@ jobs:
           path: trivy-image-results.sarif
           if-no-files-found: error
 
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Upload Trivy scan results to GitHub Security tab (on `main`)
         uses: github/codeql-action/upload-sarif@v3
+        # only on `main`
         if: ${{ github.ref == 'refs/heads/main' }} # Bypass non-zero exit code..
         with:
           sarif_file: "trivy-image-results.sarif"
@@ -69,7 +70,9 @@ jobs:
       - name: Print trivy results (sarif format)
         run: cat trivy-image-results.sarif
 
-      - name: Fail build on High/Criticial Vulnerabilities
+      - name: Fail build on High/Criticial Vulnerabilities (on branches)
+        # ignore on `main`
+        if: ${{ github.ref != 'refs/heads/main' }}
         uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db

--- a/.github/workflows/backend-build-image-and-scan.yml
+++ b/.github/workflows/backend-build-image-and-scan.yml
@@ -38,7 +38,7 @@ jobs:
         run: ./gradlew bootBuildImage
 
       - name: Run Trivy vulnerability image scanner
-        # Note: This scan is what is shown in the GitHub Security tab
+        # Note: Results are shown in the GitHub Security tab
         #       cf. step "Upload Trivy scan results to GitHub Security tab"
         # Third-party action, pin to commit SHA!
         # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions

--- a/.github/workflows/frontend-build-image-and-scan.yml
+++ b/.github/workflows/frontend-build-image-and-scan.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - name: Run Trivy vulnerability image scanner
-        # Note: This scan is what is shown in the GitHub Security tab
+        # Note: Results are shown in the GitHub Security tab
         #       cf. step "Upload Trivy scan results to GitHub Security tab"
         # Third-party action, pin to commit SHA!
         # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions

--- a/.github/workflows/frontend-build-image-and-scan.yml
+++ b/.github/workflows/frontend-build-image-and-scan.yml
@@ -40,8 +40,9 @@ jobs:
           path: trivy-image-results.sarif
           if-no-files-found: error
 
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Upload Trivy scan results to GitHub Security tab (on `main`)
         uses: github/codeql-action/upload-sarif@v3
+        # only on main
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           sarif_file: "trivy-image-results.sarif"
@@ -49,7 +50,9 @@ jobs:
       - name: Print trivy results (sarif format)
         run: cat trivy-image-results.sarif
 
-      - name: Fail build on High/Criticial Vulnerabilities
+      - name: Fail build on High/Criticial Vulnerabilities (on branches)
+        # ignored on main
+        if: ${{ github.ref != 'refs/heads/main' }}
         uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db

--- a/.github/workflows/security-jobs.yml
+++ b/.github/workflows/security-jobs.yml
@@ -63,7 +63,7 @@ jobs:
           retention-days: 3
           path: trivy-fs-results.sarif
 
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Upload Trivy scan results to GitHub Security tab (on `main`)
         # only on main
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: github/codeql-action/upload-sarif@v3
@@ -73,9 +73,9 @@ jobs:
       - name: Print trivy fs results
         run: cat trivy-fs-results.sarif
 
-      - name: Fail build on High/Criticial Vulnerabilities
+      - name: Fail build on High/Criticial Vulnerabilities (on branches)
         # ignore on main
-        if: ${{ github.ref != 'refs/heads/main' }} 
+        if: ${{ github.ref != 'refs/heads/main' }}
         uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db

--- a/.github/workflows/security-jobs.yml
+++ b/.github/workflows/security-jobs.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  security-scan-with-trivy:
+  repository-filesystem-scan-with-trivy:
+    # Note: Results are shown in the GitHub Security tab
+    #       cf. step "Upload Trivy scan results to GitHub Security tab"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -62,8 +64,9 @@ jobs:
           path: trivy-fs-results.sarif
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        # only on main
         if: ${{ github.ref == 'refs/heads/main' }}
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-fs-results.sarif"
 
@@ -71,6 +74,8 @@ jobs:
         run: cat trivy-fs-results.sarif
 
       - name: Fail build on High/Criticial Vulnerabilities
+        # ignore on main
+        if: ${{ github.ref != 'refs/heads/main' }} 
         uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db


### PR DESCRIPTION
**Related Issue**

https://digitalservicebund.atlassian.net/browse/RISDEV-8417

**Description**

When PRs introduce security issues, they should be blocked from being merged.

When `main` starts failing by itself, it's probably because trivy learned about a new CVE or similar. In this case, the code is live already and blocking the pipeline does not help security.

However, the state of main will show in the GitHub Security Tab, so our maintenance shift will notice.
