### PR TITLE
RISDEV-8540: Add api service

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,6 +45,7 @@
         "@vueuse/core": "^13.4.0",
         "axios": "^1.10.0",
         "dayjs": "^1.11.13",
+        "keycloak-js": "^26.2.0",
         "postcss": "^8.5.6",
         "primevue": "^4.3.5",
         "unplugin-icons": "^22.1.0",
@@ -7478,6 +7479,12 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/keycloak-js": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.0.tgz",
+      "integrity": "sha512-CrFcXTN+d6J0V/1v3Zpioys6qHNWE6yUzVVIsCUAmFn9H14GZ0vuYod+lt+SSpMgWGPuneDZBSGBAeLBFuqjsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,7 @@
     "@vueuse/core": "^13.4.0",
     "axios": "^1.10.0",
     "dayjs": "^1.11.13",
+    "keycloak-js": "^26.2.0",
     "postcss": "^8.5.6",
     "primevue": "^4.3.5",
     "unplugin-icons": "^22.1.0",

--- a/frontend/src/components/normgeber/InstitutionDropDown.spec.ts
+++ b/frontend/src/components/normgeber/InstitutionDropDown.spec.ts
@@ -44,6 +44,7 @@ describe('InstitutionDropDown', () => {
   it('renders the component and fetches institutions', async () => {
     const wrapper = mount(InstitutionDropDown, {
       props: {
+        inputId: 'foo',
         isInvalid: false,
         modelValue: undefined,
       },
@@ -57,6 +58,7 @@ describe('InstitutionDropDown', () => {
   it('emits updated model value when selection changes', async () => {
     const wrapper = mount(InstitutionDropDown, {
       props: {
+        inputId: 'foo',
         isInvalid: false,
         modelValue: undefined,
       },

--- a/frontend/src/components/normgeber/RegionDropDown.spec.ts
+++ b/frontend/src/components/normgeber/RegionDropDown.spec.ts
@@ -38,6 +38,7 @@ describe('RegionDropDown', () => {
   it('renders the component and fetches regions', async () => {
     const wrapper = mount(RegionDropDown, {
       props: {
+        inputId: 'foo',
         isInvalid: false,
         modelValue: undefined,
       },
@@ -51,6 +52,7 @@ describe('RegionDropDown', () => {
   it('emits updated model value when selection changes', async () => {
     const wrapper = mount(RegionDropDown, {
       props: {
+        inputId: 'foo',
         isInvalid: false,
         modelValue: undefined,
       },

--- a/frontend/src/services/apiService.spec.ts
+++ b/frontend/src/services/apiService.spec.ts
@@ -1,0 +1,198 @@
+import { INVALID_URL } from '@/services/apiService'
+import { flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Auth from '@/services/auth'
+
+vi.mock('@/services/auth', () => ({
+  useAuthentication: () => ({
+    addAuthorizationHeader: vi.fn().mockImplementation((init) => init),
+    tryRefresh: vi.fn().mockResolvedValue(true),
+  }),
+}))
+
+describe('useApiFetch', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.resetModules()
+  })
+
+  it('defaults to JSON for request and response bodies', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('{}'))
+
+    const { useApiFetch } = await import('@/services/apiService')
+
+    useApiFetch('foo/bar')
+
+    await vi.waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/v1/foo/bar',
+        expect.objectContaining({
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+        }),
+      ),
+    )
+  })
+
+  it('allows replacing the content headers', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('{}'))
+
+    const { useApiFetch } = await import('@/services/apiService')
+
+    useApiFetch('foo/bar', {
+      beforeFetch(c) {
+        c.options.headers = {
+          ...c.options.headers,
+          Accept: 'text/html',
+          'Content-Type': 'text/html',
+        }
+      },
+    })
+
+    await vi.waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/v1/foo/bar',
+        expect.objectContaining({
+          headers: {
+            Accept: 'text/html',
+            'Content-Type': 'text/html',
+          },
+        }),
+      ),
+    )
+  })
+
+  it('aborts the request if the URL is marked as invalid', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('{}'))
+
+    const { useApiFetch } = await import('@/services/apiService')
+
+    useApiFetch(INVALID_URL, { refetch: true })
+    await flushPromises()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  // Activate once keycloak is in place
+  it.skip('adds the Authorization header if available', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('{}'))
+
+    vi.spyOn(Auth, 'useAuthentication').mockReturnValue({
+      addAuthorizationHeader: (init) => {
+        return { ...init, Authorization: 'Bearer 1234' }
+      },
+      configure: vi.fn().mockResolvedValue(undefined),
+      isConfigured: vi.fn().mockReturnValue(true),
+      getUsername: vi.fn().mockReturnValue('Jane Doe'),
+      getLogoutLink: vi.fn().mockReturnValue(undefined),
+      tryRefresh: vi.fn().mockResolvedValue(true),
+    })
+
+    const { useApiFetch } = await import('@/services/apiService')
+
+    useApiFetch('foo/bar')
+
+    await vi.waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/v1/foo/bar',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer 1234' }),
+        }),
+      ),
+    )
+  })
+
+  it("doesn't add an Authorization header if none is available", async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('{}'))
+
+    const { useApiFetch } = await import('@/services/apiService')
+
+    useApiFetch('foo/bar')
+
+    await vi.waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/v1/foo/bar',
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            Authorization: 'Bearer 1234',
+          }),
+        }),
+      ),
+    )
+  })
+
+  // Activate once keycloak is in place
+  it.skip('attempts a token refresh before sending the request', async () => {
+    vi.spyOn(window, 'fetch').mockResolvedValue(new Response('{}'))
+
+    const tryRefresh = vi.fn().mockResolvedValue(true)
+
+    vi.spyOn(Auth, 'useAuthentication').mockReturnValue({
+      addAuthorizationHeader: (init) => {
+        return { ...init, Authorization: 'Bearer 1234' }
+      },
+      configure: vi.fn().mockResolvedValue(undefined),
+      isConfigured: vi.fn().mockReturnValue(true),
+      getUsername: vi.fn().mockReturnValue('Jane Doe'),
+      getLogoutLink: vi.fn().mockReturnValue(undefined),
+      tryRefresh,
+    })
+
+    const { useApiFetch } = await import('@/services/apiService')
+
+    useApiFetch('foo/bar')
+
+    await vi.waitFor(() => expect(tryRefresh).toHaveBeenCalled())
+  })
+
+  it('sends the request if the token refresh is successful', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('{}'))
+
+    const tryRefresh = vi.fn().mockResolvedValue(true)
+
+    vi.spyOn(Auth, 'useAuthentication').mockReturnValue({
+      addAuthorizationHeader: (init) => {
+        return { ...init, Authorization: 'Bearer 1234' }
+      },
+      configure: vi.fn().mockResolvedValue(undefined),
+      isConfigured: vi.fn().mockReturnValue(true),
+      getUsername: vi.fn().mockReturnValue('Jane Doe'),
+      getLogoutLink: vi.fn().mockReturnValue(undefined),
+      tryRefresh,
+    })
+
+    const { useApiFetch } = await import('@/services/apiService')
+
+    useApiFetch('foo/bar')
+
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled())
+  })
+
+  // Activate once keycloak is in place
+  it.skip('aborts the request if the token refresh fails', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('{}'))
+
+    const tryRefresh = vi.fn().mockResolvedValue(false)
+
+    vi.spyOn(Auth, 'useAuthentication').mockReturnValue({
+      addAuthorizationHeader: (init) => {
+        return { ...init, Authorization: 'Bearer 1234' }
+      },
+      configure: vi.fn().mockResolvedValue(undefined),
+      isConfigured: vi.fn().mockReturnValue(true),
+      getUsername: vi.fn().mockReturnValue('Jane Doe'),
+      getLogoutLink: vi.fn().mockReturnValue(undefined),
+      tryRefresh,
+    })
+
+    const { useApiFetch } = await import('@/services/apiService')
+
+    useApiFetch('foo/bar')
+
+    await flushPromises()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/services/apiService.spec.ts
+++ b/frontend/src/services/apiService.spec.ts
@@ -25,7 +25,7 @@ describe('useApiFetch', () => {
 
     await vi.waitFor(() =>
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/v1/foo/bar',
+        '/api/foo/bar',
         expect.objectContaining({
           headers: {
             Accept: 'application/json',
@@ -53,7 +53,7 @@ describe('useApiFetch', () => {
 
     await vi.waitFor(() =>
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/v1/foo/bar',
+        '/api/foo/bar',
         expect.objectContaining({
           headers: {
             Accept: 'text/html',
@@ -113,7 +113,7 @@ describe('useApiFetch', () => {
 
     await vi.waitFor(() =>
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/v1/foo/bar',
+        '/api/foo/bar',
         expect.objectContaining({
           headers: expect.not.objectContaining({
             Authorization: 'Bearer 1234',

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -1,0 +1,87 @@
+import { useAuthentication } from '@/services/auth'
+import type { UseFetchReturn } from '@vueuse/core'
+import { createFetch } from '@vueuse/core'
+
+/**
+ * The same as UseFetchReturn, but without the methods to get more specific useFetch instances.
+ */
+export type SimpleUseFetchReturn<T> = Omit<
+  UseFetchReturn<T>,
+  | 'get'
+  | 'post'
+  | 'put'
+  | 'delete'
+  | 'patch'
+  | 'head'
+  | 'options'
+  | 'json'
+  | 'text'
+  | 'blob'
+  | 'arrayBuffer'
+  | 'formData'
+>
+
+/* -------------------------------------------------- *
+ * Reactive API fetch                                 *
+ * -------------------------------------------------- */
+
+/** Fetch data from the backend api using useFetch. */
+export const useApiFetch = createFetch({
+  baseUrl: '/api/v1',
+
+  options: {
+    async beforeFetch({ options, url, cancel }) {
+      // useFetch requires the URL to always be there, but in some cases we
+      // can't construct a meaningful URL (e.g. because a required param is
+      // missing). For those cases we introduce INVALID_URL as a convention
+      // to tell useFetch to cancel the request.
+      if (url.endsWith(INVALID_URL)) {
+        cancel()
+        return
+      }
+
+      // Only set the Content-Type if the body is not FormData
+      if (!(options.body instanceof FormData)) {
+        options.headers = {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          ...options.headers,
+        }
+      } else {
+        // Let the browser handle the Content-Type for FormData
+        options.headers = {
+          Accept: 'application/json',
+          ...options.headers,
+        }
+      }
+
+      // Authorize requests
+      /** Set the auth headers once we have keycloak in place       
+      const { addAuthorizationHeader, tryRefresh } = useAuthentication()
+
+      const hasValidSession = await tryRefresh()
+      if (!hasValidSession) cancel()
+
+      options.headers = addAuthorizationHeader(options.headers)
+      */
+
+      return { options }
+    },
+  },
+})
+
+/**
+ * Special string that can be used in places where you want to express that
+ * a URL should not be fetched or used in any way, but you are still required
+ * to provide a string value (e.g. when providing a computed URL to useFetch).
+ * Example:
+ *
+ * ```ts
+ * const url = computed(() => someCondition ? 'example.com' : INVALID_URL)
+ * useFetch(url, {
+ *   beforeFetch(ctx) {
+ *     if (url === INVALID_URL) ctx.abort()
+ *   }
+ * })
+ */
+export const INVALID_URL = '__invalid_url__'

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -1,4 +1,3 @@
-import { useAuthentication } from '@/services/auth'
 import type { UseFetchReturn } from '@vueuse/core'
 import { createFetch } from '@vueuse/core'
 
@@ -27,7 +26,7 @@ export type SimpleUseFetchReturn<T> = Omit<
 
 /** Fetch data from the backend api using useFetch. */
 export const useApiFetch = createFetch({
-  baseUrl: '/api/v1',
+  baseUrl: '/api',
 
   options: {
     async beforeFetch({ options, url, cancel }) {
@@ -54,16 +53,6 @@ export const useApiFetch = createFetch({
           ...options.headers,
         }
       }
-
-      // Authorize requests
-      /** Set the auth headers once we have keycloak in place       
-      const { addAuthorizationHeader, tryRefresh } = useAuthentication()
-
-      const hasValidSession = await tryRefresh()
-      if (!hasValidSession) cancel()
-
-      options.headers = addAuthorizationHeader(options.headers)
-      */
 
       return { options }
     },

--- a/frontend/src/services/auth.spec.ts
+++ b/frontend/src/services/auth.spec.ts
@@ -1,0 +1,297 @@
+import * as Keycloak from 'keycloak-js'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('keycloak-js', () => {
+  const MockKeycloak = vi.fn()
+  MockKeycloak.prototype.init = vi.fn().mockResolvedValue(true)
+  MockKeycloak.prototype.didInitialize = false
+  MockKeycloak.prototype.token = undefined
+  MockKeycloak.prototype.idTokenParsed = undefined
+  MockKeycloak.prototype.createLogoutUrl = vi.fn().mockReturnValue(undefined)
+  MockKeycloak.prototype.updateToken = vi.fn().mockResolvedValue(true)
+
+  return { default: MockKeycloak }
+})
+
+describe('auth', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+    vi.resetModules()
+  })
+
+  it('configures a new instance', async () => {
+    const { useAuthentication } = await import('./auth.ts')
+    const { configure } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    expect(Keycloak.default).toHaveBeenCalledWith({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    expect(Keycloak.default.prototype.init).toHaveBeenCalled()
+  })
+
+  it('replaces an existing instance when configuring again', async () => {
+    const { useAuthentication } = await import('./auth.ts')
+    const { configure } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client-1',
+      realm: 'test-realm-1',
+      url: 'http://test.url/1',
+    })
+
+    await configure({
+      clientId: 'test-client-2',
+      realm: 'test-realm-2',
+      url: 'http://test.url/2',
+    })
+
+    expect(Keycloak.default).toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: 'test-client-1' }),
+    )
+    expect(Keycloak.default).toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: 'test-client-2' }),
+    )
+
+    expect(Keycloak.default.prototype.init).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws an error when configuration fails', async () => {
+    vi.spyOn(Keycloak.default.prototype, 'init').mockRejectedValueOnce('Error')
+    const { useAuthentication } = await import('./auth.ts')
+    const { configure } = useAuthentication()
+
+    await expect(() =>
+      configure({
+        clientId: 'test-client',
+        realm: 'test-realm',
+        url: 'http://test.url',
+      }),
+    ).rejects.toThrow(expect.objectContaining({ cause: 'Error' }))
+  })
+
+  it('returns that it is configured', async () => {
+    const { useAuthentication } = await import('./auth.ts')
+    const { configure, isConfigured } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    expect(isConfigured()).toBe(false)
+  })
+
+  it('returns that it is not configured', async () => {
+    const { useAuthentication } = await import('./auth.ts')
+    const { isConfigured } = useAuthentication()
+
+    expect(isConfigured()).toBe(false)
+  })
+
+  it('adds an authorization header when a token is available', async () => {
+    vi.spyOn(Keycloak.default.prototype, 'token', 'get').mockReturnValue('1234')
+    const { useAuthentication } = await import('./auth.ts')
+    const { configure, addAuthorizationHeader } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    const headers = addAuthorizationHeader()
+
+    // @ts-expect-error TypeScript is not sure it's there, but that's what we're testing
+    expect(headers.Authorization).toBe('Bearer 1234')
+  })
+
+  it("doesn't add an authorization header when no token is available", async () => {
+    vi.spyOn(Keycloak.default.prototype, 'token', 'get').mockReturnValue(undefined)
+    const { useAuthentication } = await import('./auth.ts')
+    const { addAuthorizationHeader } = useAuthentication()
+
+    const headers = addAuthorizationHeader()
+
+    // @ts-expect-error TypeScript is not sure it's there, but that's what we're testing
+    expect(headers.Authorization).toBeFalsy()
+  })
+
+  it('includes the original headers when adding an authorization header', async () => {
+    vi.spyOn(Keycloak.default.prototype, 'token', 'get').mockReturnValue('1234')
+    const { useAuthentication } = await import('./auth.ts')
+    const { configure, addAuthorizationHeader } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    const headers = addAuthorizationHeader({ test: 'true' })
+
+    // @ts-expect-error TypeScript is not sure it's there, but that's what we're testing
+    expect(headers.test).toBe('true')
+  })
+
+  it('returns the username', async () => {
+    vi.spyOn(Keycloak.default.prototype, 'idTokenParsed', 'get').mockReturnValue({
+      name: 'Jane Doe',
+    })
+    const { useAuthentication } = await import('./auth.ts')
+    const { configure, getUsername } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    const username = getUsername()
+
+    expect(username).toBe('Jane Doe')
+  })
+
+  it('returns undefined as the username if no token exists', async () => {
+    vi.spyOn(Keycloak.default.prototype, 'idTokenParsed', 'get').mockReturnValue(undefined)
+    const { useAuthentication } = await import('./auth.ts')
+    const { configure, getUsername } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    const username = getUsername()
+
+    expect(username).toBeUndefined()
+  })
+
+  it('returns a logout link', async () => {
+    vi.spyOn(Keycloak.default.prototype, 'createLogoutUrl').mockReturnValue('http://example.com')
+
+    const { useAuthentication } = await import('./auth.ts')
+    const { configure, getLogoutLink } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    const logoutLink = getLogoutLink()
+
+    expect(logoutLink).toBe('http://example.com')
+  })
+
+  it('returns false when attempting to refresh a token before configuring auth', async () => {
+    const { useAuthentication } = await import('./auth.ts')
+    const { tryRefresh } = useAuthentication()
+
+    const result = await tryRefresh()
+
+    expect(result).toBe(false)
+  })
+
+  it('returns false when the token refresh throws', async () => {
+    vi.spyOn(Keycloak.default.prototype, 'updateToken').mockImplementation(() => {
+      throw new Error()
+    })
+
+    const { useAuthentication } = await import('./auth.ts')
+    const { tryRefresh, configure } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    const result = await tryRefresh()
+
+    expect(result).toBe(false)
+  })
+
+  it('returns true when the token refresh succeeds', async () => {
+    vi.spyOn(Keycloak.default.prototype, 'updateToken').mockResolvedValue(true)
+    const { useAuthentication } = await import('./auth.ts')
+    const { tryRefresh, configure } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    const result = await tryRefresh()
+
+    expect(result).toBe(true)
+  })
+
+  it("returns true when the token doesn't need refreshing", async () => {
+    vi.spyOn(Keycloak.default.prototype, 'updateToken').mockResolvedValue(false)
+    const { useAuthentication } = await import('./auth.ts')
+    const { tryRefresh, configure } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    const result = await tryRefresh()
+
+    expect(result).toBe(true)
+  })
+
+  it("doesn't run multiple token refresh requests at the same time", async () => {
+    vi.spyOn(Keycloak.default.prototype, 'updateToken').mockResolvedValue(true)
+
+    const { useAuthentication } = await import('./auth.ts')
+    const { tryRefresh, configure } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    const result1 = tryRefresh()
+    const result2 = tryRefresh()
+
+    await expect(result1).resolves.toBe(true)
+    await expect(result2).resolves.toBe(true)
+    expect(Keycloak.default.prototype.updateToken).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs multiple token refresh requests sequentially', async () => {
+    vi.spyOn(Keycloak.default.prototype, 'updateToken').mockResolvedValue(true)
+
+    const { useAuthentication } = await import('./auth.ts')
+    const { tryRefresh, configure } = useAuthentication()
+
+    await configure({
+      clientId: 'test-client',
+      realm: 'test-realm',
+      url: 'http://test.url',
+    })
+
+    const result1 = tryRefresh()
+    await expect(result1).resolves.toBe(true)
+    expect(Keycloak.default.prototype.updateToken).toHaveBeenCalledTimes(1)
+
+    const result2 = tryRefresh()
+    await expect(result2).resolves.toBe(true)
+    expect(Keycloak.default.prototype.updateToken).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,125 @@
+import type { KeycloakConfig } from 'keycloak-js'
+import Keycloak from 'keycloak-js'
+
+export type AuthenticationConfig = KeycloakConfig
+
+function createAuthentication() {
+  let keycloak: Keycloak | undefined = undefined
+
+  /**
+   * Initializes the authentication with the specified configuration. Once
+   * configured, login page redirects, token refresh, etc. will automatically
+   * be managed, and you can use `addAuthorizationHeader` for authenticating
+   * backend requests.
+   *
+   * Calling this function repeatedly will replace any existing instance with
+   * the new configuration.
+   *
+   * @param config Configuration for authentication
+   * @throws Error if the authentication fails to initialize, e.g. due to an
+   *  invalid configuration.
+   */
+  async function configure(config: AuthenticationConfig): Promise<void> {
+    keycloak = new Keycloak(config)
+
+    try {
+      await keycloak.init({
+        onLoad: 'login-required',
+        checkLoginIframe: false,
+        pkceMethod: 'S256',
+        scope: 'profile email',
+      })
+    } catch (e) {
+      keycloak = undefined
+      throw new Error('Failed to initialize authentication', { cause: e })
+    }
+  }
+
+  /**
+   * Whether the authentication has already been configured successfully using
+   * `configure`.
+   *
+   * @returns True if authentication is currently active
+   */
+  function isConfigured(): boolean {
+    return keycloak?.didInitialize ?? false
+  }
+
+  /**
+   * Adds an Authorization header with the current token to a set of headers.
+   * If authentication hasn't been configured yet, this method will do nothing.
+   *
+   * @param init If you already have some headers, provide them as `init` and
+   *  this method will add the Authorization header to the list.
+   * @returns New headers
+   */
+  function addAuthorizationHeader(init?: HeadersInit): HeadersInit {
+    init ??= {}
+    if (!keycloak?.token) return init
+    return { ...init, Authorization: `Bearer ${keycloak?.token}` }
+  }
+
+  /**
+   * Returns the name of the currently active user, if they have a name and
+   * authentication has been configured. Otherwise `undefined` is returned.
+   *
+   * @returns Name of the logged in user if known
+   */
+  function getUsername(): string | undefined {
+    return keycloak?.idTokenParsed?.name
+  }
+
+  /**
+   * Creates a URL which, when visited, ends the current session and redirects
+   * the user to the login page. Can be undefined if keycloak hasn't been configured
+   * yet.
+   */
+  function getLogoutLink(): string | undefined {
+    return keycloak?.createLogoutUrl()
+  }
+
+  let pendingRefresh: Promise<boolean> | null = null
+
+  /**
+   * Attempts to refresh the token. If the refresh fails (e.g. because the user
+   * has logged out in a different tab), the user is automatically redirected to
+   * the login page.
+   *
+   * Repeated calls to refresh the token will automatically be de-duplicated,
+   * so consumers of this method don't need to worry about triggering multiple
+   * token refreshes at the same time.
+   *
+   * @returns A boolean indicating whether a valid token exists after the
+   *  attempt. This will be true if the current token can still be used,
+   *  or if it has been refreshed successfully. It will be false if keycloak
+   *  hasn't been initialized, or the refresh has failed.
+   */
+  async function tryRefresh(): Promise<boolean> {
+    if (!keycloak) return false
+
+    try {
+      pendingRefresh ??= keycloak.updateToken()
+      await pendingRefresh
+      return true
+    } catch {
+      return false
+    } finally {
+      pendingRefresh = null
+    }
+  }
+
+  return () => ({
+    addAuthorizationHeader,
+    configure,
+    getLogoutLink,
+    getUsername,
+    isConfigured,
+    tryRefresh,
+  })
+}
+
+/**
+ * Exposes utilities related to authenticating users and requests in the
+ * frontend.
+ */
+export const useAuthentication = createAuthentication()

--- a/frontend/src/services/comboboxItemService.ts
+++ b/frontend/src/services/comboboxItemService.ts
@@ -1,6 +1,5 @@
-import { useFetch, type UseFetchReturn } from '@vueuse/core'
+import type { UseFetchReturn } from '@vueuse/core'
 import type { Ref } from 'vue'
-import { API_PREFIX } from './httpClient'
 import type { ComboboxInputModelType, ComboboxItem } from '@/components/input/types'
 import LegalPeriodical from '@/domain/legalPeriodical.ts'
 import type { ComboboxResult } from '@/domain/comboboxResult.ts'
@@ -12,6 +11,7 @@ import type { FieldOfLaw } from '@/domain/fieldOfLaw'
 import errorMessages from '@/i18n/errors.json'
 import type { Court } from '@/domain/court'
 import type { DocumentType } from '@/domain/documentType'
+import { useApiFetch } from './apiService'
 
 enum Endpoint {
   documentTypes = 'lookup-tables/document-types',
@@ -72,10 +72,10 @@ function fetchFromEndpoint(
     if (endpoint == Endpoint.fieldsOfLaw) {
       queryParams = queryParams.replace('searchTerm', 'identifier')
     }
-    return `${API_PREFIX}${endpoint}?${queryParams}`
+    return `${endpoint}?${queryParams}`
   })
 
-  return useFetch<ComboboxItem[]>(url, {
+  return useApiFetch<ComboboxItem[]>(url, {
     afterFetch: (ctx) => {
       switch (endpoint) {
         case Endpoint.documentTypes:

--- a/frontend/src/services/institutionService.spec.ts
+++ b/frontend/src/services/institutionService.spec.ts
@@ -1,40 +1,39 @@
 import { useFetchInstitutions } from '@/services/institutionService'
 import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 
-vi.mock('@vueuse/core', () => {
+vi.mock('@/services/apiService', () => {
   return {
-    useFetch: vi.fn(() => ({
-      json: vi.fn(() => ({
-        data: {
-          value: {
-            institutions: [
-              {
-                id: 'institutionId1',
-                name: 'Erstes Organ',
-                officialName: 'Organ Eins',
-                type: 'INSTITUTION',
-                regions: [],
-              },
-              {
-                id: 'institutionId2',
-                name: 'Zweite Jurpn',
-                officialName: null,
-                type: 'LEGAL_ENTITY',
-                regions: [],
-              },
-            ],
-          },
-        },
-      })),
-    })),
+    useApiFetch: vi.fn().mockReturnValue({
+      json: () => ({
+        data: ref({
+          institutions: [
+            {
+              id: 'institutionId1',
+              name: 'Erstes Organ',
+              officialName: 'Organ Eins',
+              type: 'INSTITUTION',
+              regions: [],
+            },
+            {
+              id: 'institutionId2',
+              name: 'Zweite Jurpn',
+              officialName: null,
+              type: 'LEGAL_ENTITY',
+              regions: [],
+            },
+          ],
+        }),
+      }),
+    }),
   }
 })
 
 describe('institution service', () => {
-  it('calls useFetch with the correct URL and returns institutions', async () => {
-    const result = await useFetchInstitutions()
+  it('calls useApiFetch with the correct URL and returns institutions', async () => {
+    const { data } = await useFetchInstitutions()
 
-    expect(result.data.value?.institutions).toHaveLength(2)
-    expect(result.data.value?.institutions?.[0].name).toBe('Erstes Organ')
+    expect(data.value?.institutions).toHaveLength(2)
+    expect(data.value?.institutions[0].name).toBe('Erstes Organ')
   })
 })

--- a/frontend/src/services/institutionService.ts
+++ b/frontend/src/services/institutionService.ts
@@ -1,12 +1,9 @@
-import { useFetch } from '@vueuse/core'
 import type { Institution } from '@/domain/normgeber.ts'
-import { API_PREFIX } from '@/services/httpClient.ts'
+import { useApiFetch } from '@/services/apiService'
+import type { UseFetchReturn } from '@vueuse/core'
 
-const INSTITUTION_URL = `${API_PREFIX}lookup-tables/institutions`
+const INSTITUTION_URL = `/lookup-tables/institutions`
 
-export function useFetchInstitutions() {
-  return useFetch<{ institutions: Institution[] }>(
-    `${INSTITUTION_URL}?usePagination=false`,
-    {},
-  ).json()
+export function useFetchInstitutions(): UseFetchReturn<{ institutions: Institution[] }> {
+  return useApiFetch(`${INSTITUTION_URL}?usePagination=false`, {}).json()
 }

--- a/frontend/src/services/regionService.spec.ts
+++ b/frontend/src/services/regionService.spec.ts
@@ -1,36 +1,35 @@
 import { describe, expect, it, vi } from 'vitest'
 import { useFetchRegions } from './regionService'
+import { ref } from 'vue'
 
-vi.mock('@vueuse/core', () => {
+vi.mock('@/services/apiService', () => {
   return {
-    useFetch: vi.fn(() => ({
-      json: vi.fn(() => ({
-        data: {
-          value: {
-            regions: [
-              {
-                id: 'regionId0',
-                code: 'AA',
-                longText: null,
-              },
-              {
-                id: 'regionId1',
-                code: 'BB',
-                longText: null,
-              },
-            ],
-          },
-        },
-      })),
-    })),
+    useApiFetch: vi.fn().mockReturnValue({
+      json: () => ({
+        data: ref({
+          regions: [
+            {
+              id: 'regionId0',
+              code: 'AA',
+              longText: null,
+            },
+            {
+              id: 'regionId1',
+              code: 'BB',
+              longText: null,
+            },
+          ],
+        }),
+      }),
+    }),
   }
 })
 
 describe('regions service', () => {
   it('calls useFetch with the correct URL and returns regions', async () => {
-    const result = await useFetchRegions()
+    const { data } = await useFetchRegions()
 
-    expect(result.data.value?.regions).toHaveLength(2)
-    expect(result.data.value?.regions?.[0].code).toBe('AA')
+    expect(data.value?.regions).toHaveLength(2)
+    expect(data.value?.regions[0].code).toBe('AA')
   })
 })

--- a/frontend/src/services/regionService.ts
+++ b/frontend/src/services/regionService.ts
@@ -1,9 +1,9 @@
-import { useFetch } from '@vueuse/core'
 import type { Region } from '@/domain/normgeber.ts'
-import { API_PREFIX } from '@/services/httpClient.ts'
+import { useApiFetch } from '@/services/apiService'
+import type { UseFetchReturn } from '@vueuse/core'
 
-const REGION_URL = `${API_PREFIX}lookup-tables/regions`
+const REGION_URL = '/lookup-tables/regions'
 
-export function useFetchRegions() {
-  return useFetch<{ regions: Region[] }>(`${REGION_URL}?usePagination=false`, {}).json()
+export function useFetchRegions(): UseFetchReturn<{ regions: Region[] }> {
+  return useApiFetch(`${REGION_URL}?usePagination=false`, {}).json()
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,8 +6,7 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
-      environment: 'node',
-      environmentMatchGlobs: [['src/components/**', 'jsdom']],
+      environment: 'jsdom',
       exclude: [...configDefaults.exclude, 'e2e/**'],
       globals: true,
       setupFiles: ['./vitest-setup.ts'],


### PR DESCRIPTION
This PR adds: 
- an auth service copied from norms (inactive for now)
- an api service (from norms too)

replaces the existing useFetch with the wrapper useApiFetch whose job will be later to set the auth headers.