### PR TITLE
RISDEV-8878 Convert classifications

### DIFF
--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentationUnitControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/adapter/api/DocumentationUnitControllerTest.java
@@ -170,6 +170,7 @@ class DocumentationUnitControllerTest {
             """
             {
               "documentNumber": "KSNR054920707",
+              "dokumenttyp": { "abbreviation": "VR", "name": "Verwaltungsregelung" },
               "fundstellen": [],
               "fieldsOfLaw": [],
               "langueberschrift": "Lange Überschrift",

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlPublishConverterServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/LdmlPublishConverterServiceIntegrationTest.java
@@ -2,6 +2,8 @@ package de.bund.digitalservice.ris.adm_vwv.application.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.bund.digitalservice.ris.adm_vwv.application.DocumentType;
+import de.bund.digitalservice.ris.adm_vwv.application.FieldOfLaw;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.business.DocumentationUnitContent;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.business.TestDocumentationUnitContent;
 import de.bund.digitalservice.ris.adm_vwv.application.converter.business.TestNormgeber;
@@ -87,7 +89,7 @@ class LdmlPublishConverterServiceIntegrationTest {
       null,
       List.of(),
       true,
-      null,
+      new DocumentType("VR", "Verwaltungsregelung"),
       null,
       List.of(),
       List.of(),
@@ -103,7 +105,8 @@ class LdmlPublishConverterServiceIntegrationTest {
     assertThat(xml).contains(
       """
       <ris:entryIntoEffectDate>2025-01-01</ris:entryIntoEffectDate>
-      <ris:expiryDate>2027-09-30</ris:expiryDate>
+      <ris:expiryDate>2027-09-30</ris:expiryDate>""".indent(20),
+      """
       <ris:dateToQuoteList>
           <ris:dateToQuoteEntry>2025-02-04</ris:dateToQuoteEntry>
           <ris:dateToQuoteEntry>2025-02-05</ris:dateToQuoteEntry>
@@ -129,7 +132,7 @@ class LdmlPublishConverterServiceIntegrationTest {
       null,
       List.of(),
       true,
-      null,
+      new DocumentType("VR", "Verwaltungsregelung"),
       null,
       List.of(),
       List.of(),
@@ -173,7 +176,7 @@ class LdmlPublishConverterServiceIntegrationTest {
       null,
       List.of(),
       true,
-      null,
+      new DocumentType("VR", "Verwaltungsregelung"),
       null,
       List.of(),
       List.of(),
@@ -216,7 +219,7 @@ class LdmlPublishConverterServiceIntegrationTest {
       <p>Zweite Zeile</p>""",
       List.of(),
       true,
-      null,
+      new DocumentType("VR", "Verwaltungsregelung"),
       null,
       List.of(),
       List.of(),
@@ -259,7 +262,7 @@ class LdmlPublishConverterServiceIntegrationTest {
       "  ",
       List.of(),
       true,
-      null,
+      new DocumentType("VR", "Verwaltungsregelung"),
       null,
       List.of(),
       List.of(),
@@ -298,7 +301,7 @@ class LdmlPublishConverterServiceIntegrationTest {
       "  ",
       List.of(),
       true,
-      null,
+      new DocumentType("VR", "Verwaltungsregelung"),
       null,
       List.of(),
       List.of(),
@@ -316,10 +319,138 @@ class LdmlPublishConverterServiceIntegrationTest {
     // then
     assertThat(xml).contains(
       """
-      <ris:metadata>
-          <ris:normgeber staat="Bundesagentur"/>
-          <ris:normgeber staat="DEU" organ="Bundesregierung"/>
-      </ris:metadata>""".indent(16)
+      <ris:normgeber staat="Bundesagentur"/>
+      <ris:normgeber staat="DEU" organ="Bundesregierung"/>""".indent(20)
+    );
+  }
+
+  @Test
+  @DisplayName("Converts three keywords to three akn:keyword in akn:classification")
+  void convertToLdml_keywords() {
+    // given
+    DocumentationUnitContent documentationUnitContent = new DocumentationUnitContent(
+      null,
+      "KSNR00000011",
+      List.of(),
+      List.of(),
+      "Lange Überschrift",
+      List.of("Schlag", "Wort", "Langer Text mit Sonderzeichen <>& und Leerzeichen"),
+      List.of(),
+      null,
+      null,
+      null,
+      "  ",
+      List.of(),
+      true,
+      new DocumentType("VR", "Verwaltungsregelung"),
+      null,
+      List.of(),
+      List.of(),
+      List.of(),
+      null,
+      List.of()
+    );
+
+    // when
+    String xml = ldmlPublishConverterService.convertToLdml(documentationUnitContent, null);
+
+    // then
+    assertThat(xml).contains(
+      """
+      <akn:classification source="attributsemantik-noch-undefiniert">
+          <akn:keyword dictionary="attributsemantik-noch-undefiniert" showAs="Schlag" value="Schlag"/>
+          <akn:keyword dictionary="attributsemantik-noch-undefiniert" showAs="Wort" value="Wort"/>
+          <akn:keyword dictionary="attributsemantik-noch-undefiniert" showAs="Langer Text mit Sonderzeichen &lt;&gt;&amp; und Leerzeichen" value="Langer Text mit Sonderzeichen &lt;&gt;&amp; und Leerzeichen"/>
+      </akn:classification>""".indent(12)
+    );
+  }
+
+  @Test
+  @DisplayName(
+    "Converts 'Sachgebiete', 'Dokumenttyp', 'Dokumenttypzusatz', and 'Aktenzeichen' into ris:metadata"
+  )
+  void convertToLdml_classifications() {
+    // given
+    DocumentationUnitContent documentationUnitContent = new DocumentationUnitContent(
+      null,
+      "KSNR00000011",
+      List.of(),
+      List.of(
+        FieldOfLaw.builder().identifier("SO-01").notation("NEW").build(),
+        FieldOfLaw.builder().identifier("03-04").notation("OLD").build()
+      ),
+      "Lange Überschrift",
+      List.of(),
+      List.of(),
+      null,
+      null,
+      null,
+      "  ",
+      List.of("X/I-43", "Akt. 45 / 2-3"),
+      false,
+      new DocumentType("VR", "Verwaltungsregelung"),
+      "Zusatz",
+      List.of(),
+      List.of(),
+      List.of(),
+      null,
+      List.of()
+    );
+
+    // when
+    String xml = ldmlPublishConverterService.convertToLdml(documentationUnitContent, null);
+
+    // then
+    assertThat(xml).contains(
+      """
+      <ris:fieldsOfLaw>
+          <ris:fieldOfLaw notation="NEW">SO-01</ris:fieldOfLaw>
+          <ris:fieldOfLaw notation="OLD">03-04</ris:fieldOfLaw>
+      </ris:fieldsOfLaw>
+      <ris:documentType category="VR" longTitle="Zusatz">VR Zusatz</ris:documentType>
+      <ris:referenceNumbers>
+          <ris:referenceNumber>X/I-43</ris:referenceNumber>
+          <ris:referenceNumber>Akt. 45 / 2-3</ris:referenceNumber>
+      </ris:referenceNumbers>""".indent(20)
+    );
+  }
+
+  @Test
+  @DisplayName(
+    "Converts 'Dokumenttyp' without 'Dokumenttypzusatz' to ris:documentType in ris:metadata"
+  )
+  void convertToLdml_noDokumenttypZusatz() {
+    // given
+    DocumentationUnitContent documentationUnitContent = new DocumentationUnitContent(
+      null,
+      "KSNR00000011",
+      List.of(),
+      List.of(),
+      "Lange Überschrift",
+      List.of(),
+      List.of(),
+      null,
+      null,
+      null,
+      "  ",
+      List.of(),
+      false,
+      new DocumentType("VR", "Verwaltungsregelung"),
+      null,
+      List.of(),
+      List.of(),
+      List.of(),
+      null,
+      List.of()
+    );
+
+    // when
+    String xml = ldmlPublishConverterService.convertToLdml(documentationUnitContent, null);
+
+    // then
+    assertThat(xml).contains(
+      """
+      <ris:documentType category="VR">VR</ris:documentType>""".indent(20)
     );
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/business/TestDocumentationUnitContent.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/adm_vwv/application/converter/business/TestDocumentationUnitContent.java
@@ -1,5 +1,6 @@
 package de.bund.digitalservice.ris.adm_vwv.application.converter.business;
 
+import de.bund.digitalservice.ris.adm_vwv.application.DocumentType;
 import java.util.List;
 
 /**
@@ -22,7 +23,7 @@ public class TestDocumentationUnitContent {
       null,
       List.of(),
       true,
-      null,
+      new DocumentType("VR", "Verwaltungsregelung"),
       null,
       List.of(),
       List.of(),


### PR DESCRIPTION
**Related Issue**

[RISDEV-8878](https://digitalservicebund.atlassian.net/browse/RISDEV-8878)

**Description**

Convert classifications 'Schlagworte', 'Dokumenttyp', 'Dokumenttypzusatz', and 'Aktenzeichen' to LDML xml.


[RISDEV-8878]: https://digitalservicebund.atlassian.net/browse/RISDEV-8878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ